### PR TITLE
chore: add GitHub issue templates for features, QA, and documentation tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: "🐛 Bug Report"
+about: Report a problem or regression in tests, CI, or code
+title: "fix: "
+labels: ["bug"]
+assignees: ""
+---
+
+## Describe the Bug
+
+A concise description of what went wrong.
+
+## To Reproduce
+
+Steps to reproduce locally or via CI.
+
+## Expected Behavior
+
+What should have happened instead?
+
+## Evidence
+
+- [ ] Link to failing GitHub Action or artifact
+- [ ] Screenshot / stack trace / log
+
+## Acceptance Criteria
+
+- [ ] Reproducible test added
+- [ ] Fix verified locally and in CI
+- [ ] Docs / README reflect fix

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Ask a general question
+    url: https://github.com/dardenkyle/site-sentry/discussions
+    about: Please start a discussion for general questions or ideas.

--- a/.github/ISSUE_TEMPLATE/dev_experience.md
+++ b/.github/ISSUE_TEMPLATE/dev_experience.md
@@ -1,0 +1,22 @@
+---
+name: "🧰 Developer Experience / Tooling"
+about: Improve linting, typing, formatting, or automation setup
+title: "dx: "
+labels: ["tooling", "maintenance"]
+assignees: ""
+---
+
+## Problem
+
+What’s inconsistent or missing in local DX / CI?
+
+## Proposal
+
+Describe the improvement (e.g., add pre-commit hooks, standardize Python 3.13, add Makefile).
+
+## Acceptance Criteria
+
+- [ ] Pre-commit runs Ruff lint/format and Mypy
+- [ ] Makefile or tasks.ps1 includes test/lint/type/fmt
+- [ ] CI reflects consistent environment
+- [ ] Documentation updated

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,27 @@
+---
+name: "📄 Documentation / README Update"
+about: Improve README, Quickstart, or architectural docs
+title: "docs: "
+labels: ["documentation"]
+assignees: ""
+---
+
+## Section(s) to Update
+
+- [ ] Quickstart
+- [ ] Reports / CI artifacts
+- [ ] Architecture diagram
+- [ ] Troubleshooting
+- [ ] Roadmap
+- [ ] Other
+
+## Goal
+
+Explain why this doc change helps recruiters, users, or devs.
+
+## Acceptance Criteria
+
+- [ ] Markdown formatting clean and consistent
+- [ ] Diagrams/images linked correctly
+- [ ] README passes link validation
+- [ ] PR reviewed and merged

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: "✨ Feature Request"
+about: Suggest a new capability or improvement for Site Sentry
+title: "feat: "
+labels: ["enhancement"]
+assignees: ""
+---
+
+## Summary
+
+Describe the feature in one clear sentence.
+
+## Motivation
+
+Why is this useful? (user impact, reliability, CI polish, visibility)
+
+## Acceptance Criteria
+
+- [ ] Behavior described clearly
+- [ ] Code + tests added or updated
+- [ ] Docs / README updated
+- [ ] CI passes on main
+
+## Example
+
+> “Add Playwright trace viewer upload so users can inspect failures directly in GitHub Actions.”

--- a/.github/ISSUE_TEMPLATE/project_task.md
+++ b/.github/ISSUE_TEMPLATE/project_task.md
@@ -1,0 +1,22 @@
+---
+name: "🗺️ Project Task / Roadmap Item"
+about: Track progress toward a larger milestone or roadmap deliverable
+title: "chore: "
+labels: ["roadmap"]
+assignees: ""
+---
+
+## Task Summary
+
+High-level milestone (e.g., “Embed screenshots in pytest-html report”).
+
+## Subtasks
+
+- [ ] Implement
+- [ ] Test locally
+- [ ] Validate CI artifact
+- [ ] Merge & verify on main
+
+## Definition of Done
+
+When CI passes with green badge and artifact contains expected outputs.

--- a/.github/ISSUE_TEMPLATE/test_improvement.md
+++ b/.github/ISSUE_TEMPLATE/test_improvement.md
@@ -1,0 +1,24 @@
+---
+name: "🧪 Test / QA Improvement"
+about: Add or enhance tests, reporting, or coverage
+title: "test: "
+labels: ["testing", "quality"]
+assignees: ""
+---
+
+## Goal
+
+Briefly describe what test coverage or CI behavior needs improvement.
+
+## Scope
+
+- [ ] Add/extend smoke suite
+- [ ] Add/extend visual regression
+- [ ] Improve HTML / JUnit reports
+- [ ] Other (specify)
+
+## Acceptance Criteria
+
+- [ ] New/updated tests committed
+- [ ] Reports (HTML + JUnit) verified in Actions
+- [ ] Screenshots / traces attach correctly


### PR DESCRIPTION
This PR adds a full suite of GitHub Issue Templates to standardize contributions, bug reports, and roadmap tracking for Site Sentry.

It improves repo organization, makes the project look professionally maintained, and allows easy linking between Issues and PRs.