### PR TITLE
fix: stop custom fixtures from dropping browser_context_args

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,8 +61,9 @@ def base_url(request: pytest.FixtureRequest) -> str:
 def browser_type_launch_args(browser_type_launch_args: dict[str, Any]) -> dict[str, Any]:
     """Extend pytest-playwright's launch arguments with env overrides.
 
-    Env vars are applied only when explicitly set, so the plugin's CLI
-    options (--headed, --slowmo, --browser-channel) keep working.
+    CLI options take precedence over env vars: the plugin only emits
+    headless/slow_mo when --headed/--slowmo are passed, and values that
+    load_dotenv() picked up from a .env file must not disable them.
 
     Args:
         browser_type_launch_args: The plugin's built-in launch arguments
@@ -71,9 +72,9 @@ def browser_type_launch_args(browser_type_launch_args: dict[str, Any]) -> dict[s
         Launch arguments with HEADLESS/SLOWMO overrides applied
     """
     launch_args = dict(browser_type_launch_args)
-    if "HEADLESS" in os.environ:
+    if "HEADLESS" in os.environ and "headless" not in launch_args:
         launch_args["headless"] = os.environ["HEADLESS"].lower() == "true"
-    if "SLOWMO" in os.environ:
+    if "SLOWMO" in os.environ and "slow_mo" not in launch_args:
         launch_args["slow_mo"] = int(os.environ["SLOWMO"])
     return launch_args
 
@@ -83,8 +84,10 @@ def browser_context_args(browser_context_args: dict[str, Any]) -> dict[str, Any]
     """Extend pytest-playwright's context arguments with env overrides.
 
     The plugin's arguments already carry base_url, --device presets, and
-    --video recording; the viewport is only overridden when configured,
-    so device presets are not clobbered by defaults.
+    --video recording. A --device preset supplies its own viewport and
+    takes precedence; the env viewport (often loaded from .env) is
+    applied only when no preset did, so presets are never clobbered,
+    fully or partially.
 
     Args:
         browser_context_args: The plugin's built-in context arguments
@@ -93,7 +96,8 @@ def browser_context_args(browser_context_args: dict[str, Any]) -> dict[str, Any]
         Context arguments with the configured viewport applied
     """
     context_args = dict(browser_context_args)
-    if "VIEWPORT_WIDTH" in os.environ or "VIEWPORT_HEIGHT" in os.environ:
+    env_viewport = "VIEWPORT_WIDTH" in os.environ or "VIEWPORT_HEIGHT" in os.environ
+    if env_viewport and "viewport" not in context_args:
         context_args["viewport"] = {
             "width": int(os.getenv("VIEWPORT_WIDTH", "1280")),
             "height": int(os.getenv("VIEWPORT_HEIGHT", "720")),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,10 @@ configuration management, and test utilities.
 import os
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from dotenv import load_dotenv
-from playwright.sync_api import Browser, BrowserContext, Page
 
 from tests.utils.logger import get_logger
 
@@ -37,82 +37,68 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> Generator[
 
 
 @pytest.fixture(scope="session")
-def base_url() -> str:
+def base_url(request: pytest.FixtureRequest) -> str:
     """Get the base URL for the site under test.
 
+    Overrides pytest-base-url's fixture so BASE_URL from the environment
+    is honored. The --base-url CLI option still wins when passed, and
+    pytest-playwright applies the result to every browser context, so
+    tests can navigate relatively via page.goto("/").
+
+    Args:
+        request: Pytest fixture request, used to read the CLI option
+
     Returns:
-        Base URL from environment or default
+        Base URL from CLI option, environment, or default
     """
-    url = os.getenv("BASE_URL", "https://kyledarden.com")
+    cli_url: str | None = request.config.getoption("--base-url")
+    url = cli_url if cli_url else os.getenv("BASE_URL", "https://kyledarden.com")
     logger.info("Using base URL: %s", url)
     return url
 
 
 @pytest.fixture(scope="session")
-def browser_type_launch_args() -> dict[str, bool | int]:
-    """Configure browser launch arguments.
+def browser_type_launch_args(browser_type_launch_args: dict[str, Any]) -> dict[str, Any]:
+    """Extend pytest-playwright's launch arguments with env overrides.
+
+    Env vars are applied only when explicitly set, so the plugin's CLI
+    options (--headed, --slowmo, --browser-channel) keep working.
+
+    Args:
+        browser_type_launch_args: The plugin's built-in launch arguments
 
     Returns:
-        Dictionary of browser launch arguments
+        Launch arguments with HEADLESS/SLOWMO overrides applied
     """
-    return {
-        "headless": os.getenv("HEADLESS", "true").lower() == "true",
-        "slow_mo": int(os.getenv("SLOWMO", "0")),
-    }
+    launch_args = dict(browser_type_launch_args)
+    if "HEADLESS" in os.environ:
+        launch_args["headless"] = os.environ["HEADLESS"].lower() == "true"
+    if "SLOWMO" in os.environ:
+        launch_args["slow_mo"] = int(os.environ["SLOWMO"])
+    return launch_args
 
 
 @pytest.fixture(scope="session")
-def browser_context_args(base_url: str) -> dict[str, dict[str, int] | str]:
-    """Configure browser context arguments.
+def browser_context_args(browser_context_args: dict[str, Any]) -> dict[str, Any]:
+    """Extend pytest-playwright's context arguments with env overrides.
+
+    The plugin's arguments already carry base_url, --device presets, and
+    --video recording; the viewport is only overridden when configured,
+    so device presets are not clobbered by defaults.
 
     Args:
-        base_url: Base URL for the site
+        browser_context_args: The plugin's built-in context arguments
 
     Returns:
-        Dictionary of browser context arguments
+        Context arguments with the configured viewport applied
     """
-    viewport: dict[str, int] = {
-        "width": int(os.getenv("VIEWPORT_WIDTH", "1280")),
-        "height": int(os.getenv("VIEWPORT_HEIGHT", "720")),
-    }
-    return {
-        "viewport": viewport,
-        "base_url": base_url,
-    }
-
-
-@pytest.fixture(scope="function")
-def page(context: BrowserContext) -> Generator[Page, None, None]:
-    """Create a new page for each test.
-
-    Args:
-        context: Browser context fixture
-
-    Yields:
-        New page instance
-    """
-    page = context.new_page()
-    logger.info("Created new page")
-    yield page
-    logger.info("Closing page")
-    page.close()
-
-
-@pytest.fixture(scope="function")
-def context(browser: Browser) -> Generator[BrowserContext, None, None]:
-    """Create a new browser context for each test.
-
-    Args:
-        browser: Browser fixture
-
-    Yields:
-        New browser context
-    """
-    context = browser.new_context()
-    logger.info("Created new browser context")
-    yield context
-    logger.info("Closing browser context")
-    context.close()
+    context_args = dict(browser_context_args)
+    if "VIEWPORT_WIDTH" in os.environ or "VIEWPORT_HEIGHT" in os.environ:
+        context_args["viewport"] = {
+            "width": int(os.getenv("VIEWPORT_WIDTH", "1280")),
+            "height": int(os.getenv("VIEWPORT_HEIGHT", "720")),
+        }
+    return context_args
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/tests/smoke/test_config.py
+++ b/tests/smoke/test_config.py
@@ -6,7 +6,7 @@ pytest-playwright built-ins and silently dropping configuration
 (issue #26).
 """
 
-import os
+from typing import Any
 
 import pytest
 from playwright.sync_api import Page
@@ -15,18 +15,23 @@ from tests.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Playwright's built-in default, used when no viewport is configured
+PLAYWRIGHT_DEFAULT_VIEWPORT = {"width": 1280, "height": 720}
+
 
 @pytest.mark.smoke
-def test_viewport_matches_configuration(page: Page) -> None:
+def test_viewport_matches_configuration(page: Page, browser_context_args: dict[str, Any]) -> None:
     """Test that the configured viewport is applied to the context.
+
+    The expectation is derived from the resolved browser_context_args,
+    so it holds for env overrides, --device presets, and the plugin
+    default alike.
 
     Args:
         page: Playwright page fixture
+        browser_context_args: Resolved browser context arguments
     """
-    expected = {
-        "width": int(os.getenv("VIEWPORT_WIDTH", "1280")),
-        "height": int(os.getenv("VIEWPORT_HEIGHT", "720")),
-    }
+    expected = browser_context_args.get("viewport", PLAYWRIGHT_DEFAULT_VIEWPORT)
     logger.info("Expecting viewport: %s", expected)
 
     assert page.viewport_size == expected, (

--- a/tests/smoke/test_config.py
+++ b/tests/smoke/test_config.py
@@ -1,0 +1,36 @@
+"""Configuration plumbing tests.
+
+Verifies that browser_context_args from conftest.py actually reach the
+browser context. Guards against custom fixtures shadowing the
+pytest-playwright built-ins and silently dropping configuration
+(issue #26).
+"""
+
+import os
+
+import pytest
+from playwright.sync_api import Page
+
+from tests.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@pytest.mark.smoke
+def test_viewport_matches_configuration(page: Page) -> None:
+    """Test that the configured viewport is applied to the context.
+
+    Args:
+        page: Playwright page fixture
+    """
+    expected = {
+        "width": int(os.getenv("VIEWPORT_WIDTH", "1280")),
+        "height": int(os.getenv("VIEWPORT_HEIGHT", "720")),
+    }
+    logger.info("Expecting viewport: %s", expected)
+
+    assert page.viewport_size == expected, (
+        f"Viewport {page.viewport_size} does not match configuration {expected}; "
+        "browser_context_args is not reaching the browser context"
+    )
+    logger.info("Viewport matches configuration")

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -15,16 +15,15 @@ logger = get_logger(__name__)
 
 
 @pytest.mark.smoke
-def test_homepage_loads(page: Page, base_url: str) -> None:
+def test_homepage_loads(page: Page) -> None:
     """Test that the homepage loads successfully.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
-    logger.info("Testing homepage load: %s", base_url)
+    logger.info("Testing homepage load")
 
-    response = page.goto(base_url)
+    response = page.goto("/")
     assert response is not None, "No response received"
     assert response.ok, f"Response not OK: {response.status}"
 
@@ -32,16 +31,15 @@ def test_homepage_loads(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.smoke
-def test_homepage_title(page: Page, base_url: str) -> None:
+def test_homepage_title(page: Page) -> None:
     """Test that the homepage has a proper title.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing homepage title")
 
-    page.goto(base_url)
+    page.goto("/")
     title = page.title()
 
     assert title, "Page title is empty"
@@ -51,12 +49,11 @@ def test_homepage_title(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.smoke
-def test_no_console_errors(page: Page, base_url: str) -> None:
+def test_no_console_errors(page: Page) -> None:
     """Test that the homepage loads without console errors.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing for console errors")
 
@@ -68,7 +65,7 @@ def test_no_console_errors(page: Page, base_url: str) -> None:
             logger.warning("Console error: %s", msg.text)
 
     page.on("console", handle_console)
-    page.goto(base_url)
+    page.goto("/")
 
     # Wait a moment for any delayed console errors
     page.wait_for_timeout(1000)
@@ -78,12 +75,11 @@ def test_no_console_errors(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.smoke
-def test_response_time(page: Page, base_url: str) -> None:
+def test_response_time(page: Page) -> None:
     """Test that the homepage loads within acceptable time.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing page load time")
 
@@ -91,7 +87,7 @@ def test_response_time(page: Page, base_url: str) -> None:
 
     start_time = time.time()
 
-    response = page.goto(base_url, wait_until="load")
+    response = page.goto("/", wait_until="load")
 
     load_time = time.time() - start_time
 
@@ -102,16 +98,15 @@ def test_response_time(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.smoke
-def test_main_content_visible(page: Page, base_url: str) -> None:
+def test_main_content_visible(page: Page) -> None:
     """Test that main content is visible on the homepage.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing main content visibility")
 
-    page.goto(base_url)
+    page.goto("/")
 
     # Check that the page has a body with content
     body = page.locator("body")

--- a/tests/ui/test_ui_nav.py
+++ b/tests/ui/test_ui_nav.py
@@ -14,16 +14,15 @@ logger = get_logger(__name__)
 
 
 @pytest.mark.ui
-def test_navigation_links_exist(page: Page, base_url: str) -> None:
+def test_navigation_links_exist(page: Page) -> None:
     """Test that navigation links are present on the page.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing navigation links presence")
 
-    page.goto(base_url)
+    page.goto("/")
 
     # Check for common navigation elements
     links = page.locator("a[href]")
@@ -34,16 +33,15 @@ def test_navigation_links_exist(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.ui
-def test_navigation_links_valid(page: Page, base_url: str) -> None:
+def test_navigation_links_valid(page: Page) -> None:
     """Test that navigation links have valid href attributes.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing navigation link validity")
 
-    page.goto(base_url)
+    page.goto("/")
 
     # Get all internal links
     links = page.locator("a[href]").all()
@@ -60,18 +58,17 @@ def test_navigation_links_valid(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.ui
-def test_responsive_viewport(page: Page, base_url: str) -> None:
+def test_responsive_viewport(page: Page) -> None:
     """Test that the site is responsive at different viewport sizes.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing responsive design")
 
     # Test mobile viewport
     page.set_viewport_size({"width": 375, "height": 667})
-    page.goto(base_url)
+    page.goto("/")
 
     body = page.locator("body")
     expect(body).to_be_visible()
@@ -94,16 +91,15 @@ def test_responsive_viewport(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.ui
-def test_images_load(page: Page, base_url: str) -> None:
+def test_images_load(page: Page) -> None:
     """Test that images on the page load successfully.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing image loading")
 
-    page.goto(base_url)
+    page.goto("/")
 
     # Wait for images to load
     page.wait_for_load_state("networkidle")
@@ -126,16 +122,15 @@ def test_images_load(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.ui
-def test_meta_tags_present(page: Page, base_url: str) -> None:
+def test_meta_tags_present(page: Page) -> None:
     """Test that essential meta tags are present.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing meta tags")
 
-    page.goto(base_url)
+    page.goto("/")
 
     # Check for viewport meta tag (important for mobile)
     viewport_meta = page.locator('meta[name="viewport"]')
@@ -152,16 +147,15 @@ def test_meta_tags_present(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.ui
-def test_favicon_exists(page: Page, base_url: str) -> None:
+def test_favicon_exists(page: Page) -> None:
     """Test that a favicon is defined.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing favicon presence")
 
-    page.goto(base_url)
+    page.goto("/")
 
     # Look for favicon link tags
     favicon_links = page.locator('link[rel*="icon"]')
@@ -175,16 +169,15 @@ def test_favicon_exists(page: Page, base_url: str) -> None:
 
 @pytest.mark.ui
 @pytest.mark.slow
-def test_page_scroll(page: Page, base_url: str) -> None:
+def test_page_scroll(page: Page) -> None:
     """Test that the page can be scrolled.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing page scroll functionality")
 
-    page.goto(base_url)
+    page.goto("/")
 
     # Get initial scroll position
     initial_scroll = page.evaluate("window.pageYOffset")
@@ -210,12 +203,11 @@ def test_page_scroll(page: Page, base_url: str) -> None:
 
 
 @pytest.mark.ui
-def test_no_broken_styles(page: Page, base_url: str) -> None:
+def test_no_broken_styles(page: Page) -> None:
     """Test that CSS stylesheets load successfully.
 
     Args:
         page: Playwright page fixture
-        base_url: Base URL fixture
     """
     logger.info("Testing CSS loading")
 
@@ -228,7 +220,7 @@ def test_no_broken_styles(page: Page, base_url: str) -> None:
                 logger.warning("Failed to load stylesheet: %s", response.url)
 
     page.on("response", handle_response)
-    page.goto(base_url)
+    page.goto("/")
     page.wait_for_load_state("networkidle")
 
     assert len(failed_resources) == 0, (


### PR DESCRIPTION
## Problem
`tests/conftest.py` defined custom `page`/`context` fixtures that shadowed the pytest-playwright built-ins and called `browser.new_context()` with **no arguments**, so `browser_context_args` never reached the browser:
- `VIEWPORT_WIDTH`/`VIEWPORT_HEIGHT` had no effect - every run used 1280x720.
- `base_url` was never set on the context, so relative navigation didn't work (tests compensated by passing `base_url` explicitly everywhere).
- Plugin features (`--browser` selection, `--device`, tracing, video) were silently discarded.

## Changes
- Deleted the custom `page`/`context` fixtures; the plugin built-ins honor `browser_context_args` and `browser_type_launch_args`.
- The `browser_type_launch_args`/`browser_context_args` overrides now **extend** the plugin's values instead of replacing them, applying `HEADLESS`/`SLOWMO`/`VIEWPORT_*` env vars only when explicitly set - so `--headed`, `--slowmo`, and `--device` presets keep working.
- `base_url` override now respects the `--base-url` CLI option, falling back to the `BASE_URL` env var as before.
- All tests use relative `page.goto("/")` now that `base_url` is applied at the context level; the redundant `base_url` params are gone.
- New `test_viewport_matches_configuration` regression guard asserts `page.viewport_size` matches the configured env values.

## Verification (acceptance criteria)
- **Repro first:** before the fix, a viewport assertion with `VIEWPORT_WIDTH=375 VIEWPORT_HEIGHT=667` failed with `viewport is {'width': 1280, 'height': 720}`. After the fix the same run passes - the env var observably changes behavior.
- `uv run pytest --browser firefox` selects Firefox with no code changes (verified after `playwright install firefox`).
- Full suite (15 tests, now navigating relatively - itself proof `base_url` reaches the context), `ruff check`, `ruff format --check`, and `mypy` strict all pass.

Closes #26