### PR TITLE
feat: alert on scheduled monitoring failures via auto-managed incident issue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,42 +53,47 @@ jobs:
           path: test-results/report.html
           retention-days: 30
 
-  # A red X in the Actions tab is not an alert: scheduled failures open
-  # (or update) a single site-down incident issue, and the next passing
-  # scheduled run closes it with the downtime recorded. Manual and PR
-  # runs never touch incident issues.
+  # A red X in the Actions tab is not an alert: any scheduled run that
+  # does not succeed (failure, timeout, cancellation) opens or updates
+  # a single site-down incident issue, and the next passing scheduled
+  # run closes it with the downtime recorded. Manual and PR runs never
+  # touch incident issues.
   alert:
     name: Manage site-down incident issue
     runs-on: ubuntu-latest
     needs: test
-    if: >-
-      always() && github.event_name == 'schedule' &&
-      contains(fromJSON('["success", "failure"]'), needs.test.result)
+    if: always() && github.event_name == 'schedule'
+    # Serialize incident side effects so overlapping runs (e.g. a
+    # re-run racing the next scheduled run) cannot duplicate the issue
+    concurrency:
+      group: site-down-incident
+      cancel-in-progress: false
     permissions:
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      TEST_RESULT: ${{ needs.test.result }}
     steps:
       - name: Open or update incident issue
-        if: needs.test.result == 'failure'
+        if: needs.test.result != 'success'
         run: |
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --label site-down --state open \
             --json number --jq '.[0].number // empty')
           if [ -z "$existing" ]; then
             gh issue create --repo "$GITHUB_REPOSITORY" \
-              --title "Site down: scheduled QA run failed" \
+              --title "Site down: scheduled QA run did not succeed" \
               --label site-down \
-              --body "The scheduled QA run against the live site failed.
+              --body "The scheduled QA run against the live site did not succeed (result: $TEST_RESULT).
 
-          - Failed run: $RUN_URL
+          - Run: $RUN_URL
           - The \`html-report\` artifact on the run has per-test details.
 
-          This issue is managed automatically: further scheduled failures add comments here, and the next passing scheduled run closes it."
+          This issue is managed automatically: further unsuccessful scheduled runs add comments here, and the next passing scheduled run closes it."
           else
             gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
-              --body "Still failing: $RUN_URL"
+              --body "Still not passing (result: $TEST_RESULT): $RUN_URL"
           fi
 
       - name: Close incident issue on recovery

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,3 +52,57 @@ jobs:
           name: html-report
           path: test-results/report.html
           retention-days: 30
+
+  # A red X in the Actions tab is not an alert: scheduled failures open
+  # (or update) a single site-down incident issue, and the next passing
+  # scheduled run closes it with the downtime recorded. Manual and PR
+  # runs never touch incident issues.
+  alert:
+    name: Manage site-down incident issue
+    runs-on: ubuntu-latest
+    needs: test
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      contains(fromJSON('["success", "failure"]'), needs.test.result)
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Open or update incident issue
+        if: needs.test.result == 'failure'
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label site-down --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$existing" ]; then
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "Site down: scheduled QA run failed" \
+              --label site-down \
+              --body "The scheduled QA run against the live site failed.
+
+          - Failed run: $RUN_URL
+          - The \`html-report\` artifact on the run has per-test details.
+
+          This issue is managed automatically: further scheduled failures add comments here, and the next passing scheduled run closes it."
+          else
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body "Still failing: $RUN_URL"
+          fi
+
+      - name: Close incident issue on recovery
+        if: needs.test.result == 'success'
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --label site-down --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            created=$(gh issue view "$existing" --repo "$GITHUB_REPOSITORY" \
+              --json createdAt --jq '.createdAt')
+            minutes=$(( ($(date +%s) - $(date -d "$created" +%s)) / 60 ))
+            gh issue close "$existing" --repo "$GITHUB_REPOSITORY" \
+              --comment "Recovered: the scheduled QA run passed after ~$((minutes / 60))h $((minutes % 60))m of downtime.
+
+          - Passing run: $RUN_URL"
+          fi


### PR DESCRIPTION
Closes #32.

## Problem

site-sentry's value is noticing when kyledarden.com breaks, but a failed scheduled run only produced a red X in the Actions tab. Case in point: the contact form silently dropped every message (dardenkyle/portfolio-site#82) while monitoring looked green and nobody was watching the tab. Monitoring without alerting is not monitoring.

## Changes

New `alert` job in `tests.yml`, downstream of the test job and gated to `schedule` events only, implemented with plain `gh` CLI (no third-party action to trust or pin):

- **Failure**: opens an issue labeled `site-down` with the failed run link and a pointer to the `html-report` artifact. If an incident is already open, it comments "Still failing" instead - repeated failures never create duplicates.
- **Recovery**: the next passing scheduled run closes the open incident with the downtime duration and the recovering run's link.
- **Isolation**: manual (`workflow_dispatch`) and PR runs never touch incident issues; the job carries its own least-privilege `issues: write` permission rather than widening the workflow's.

The `site-down` label has been created in the repo.

## Verification

Executed the exact step scripts (extracted from the YAML) against the real repository:

1. Failure with no open incident -> issue created with label, run link, artifact pointer.
2. Failure with an open incident -> "Still failing" comment on the existing issue, no duplicate.
3. Success with an open incident -> issue closed with "Recovered ... after ~0h 1m of downtime" and the passing run link.
4. Success with no open incident -> silent no-op.

Test issues were deleted afterwards. One caveat surfaced during testing: the issue-list read lags a create by a couple of seconds (two back-to-back script runs raced it), which is irrelevant at the 12-hour schedule cadence but worth knowing if the cron is ever tightened to minutes.

## Not included (deliberately)

The optional webhook notification (email/Slack/Discord) from the issue - GitHub already emails you on issue creation in your own repo, so an incident issue *is* a notification. A webhook step can be a follow-up if that proves insufficient.