### PR TITLE
test: contact form submission check (mocked FormSubmit, canary for silent failure)

### DIFF
--- a/tests/ui/test_contact_form.py
+++ b/tests/ui/test_contact_form.py
@@ -1,0 +1,109 @@
+"""Contact form tests for kyledarden.com.
+
+The form must post to FormSubmit's ajax endpoint and surface failures:
+posting to the plain endpoint (or ignoring the response body) silently
+drops messages, which is exactly what dardenkyle/portfolio-site#82
+shipped for weeks. Every request toward formsubmit.co is intercepted
+and fulfilled with a mocked response, so these tests never send email.
+"""
+
+import pytest
+from playwright.sync_api import Page, Request, Route, expect
+
+from tests.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Intercept everything sent toward FormSubmit, whatever the path, so a
+# regression to a non-ajax endpoint is captured instead of escaping
+FORMSUBMIT_URL_PATTERN = "https://formsubmit.co/**"
+
+# The only endpoint that processes programmatic (fetch) submissions
+FORMSUBMIT_AJAX_PREFIX = "https://formsubmit.co/ajax/"
+
+# FormSubmit reports both outcomes as HTTP 200; the body is the signal
+SUCCESS_BODY = '{"success": "true", "message": "The form was submitted successfully."}'
+FAILURE_BODY = '{"success": "false", "message": "Simulated FormSubmit failure"}'
+
+SUCCESS_BANNER_TEXT = "Message sent successfully"
+FAILURE_MESSAGE_TEXT = "Failed to send message"
+
+TEST_NAME = "Site Sentry"
+TEST_EMAIL = "site-sentry@example.com"
+TEST_MESSAGE = "Automated contact form check - no email is sent."
+
+
+def _submit_contact_form(page: Page, response_body: str) -> list[Request]:
+    """Fill and submit the contact form with FormSubmit fully mocked.
+
+    Args:
+        page: Playwright page to drive
+        response_body: JSON body the mocked FormSubmit returns
+
+    Returns:
+        The requests the form sent toward formsubmit.co
+    """
+    captured: list[Request] = []
+
+    def fulfill(route: Route) -> None:
+        captured.append(route.request)
+        route.fulfill(status=200, content_type="application/json", body=response_body)
+
+    page.route(FORMSUBMIT_URL_PATTERN, fulfill)
+    page.goto("/contact")
+    page.fill("#name", TEST_NAME)
+    page.fill("#email", TEST_EMAIL)
+    page.fill("#message", TEST_MESSAGE)
+    page.get_by_role("button", name="Send Message").click()
+    return captured
+
+
+@pytest.mark.ui
+def test_contact_form_targets_formsubmit_ajax(page: Page) -> None:
+    """Test that submitting sends one POST to the FormSubmit ajax endpoint.
+
+    Args:
+        page: Playwright page fixture
+    """
+    logger.info("Testing contact form submission wiring")
+
+    requests = _submit_contact_form(page, SUCCESS_BODY)
+
+    expect(page.get_by_text(SUCCESS_BANNER_TEXT)).to_be_visible()
+
+    assert len(requests) == 1, (
+        f"Expected exactly one FormSubmit request, saw {len(requests)}"
+    )
+    request = requests[0]
+    assert request.method == "POST", f"Expected POST, got {request.method}"
+    assert request.url.startswith(FORMSUBMIT_AJAX_PREFIX), (
+        f"Form posted to {request.url}; fetch submissions are only "
+        "processed on the /ajax/ endpoint (portfolio-site#82)"
+    )
+
+    post_data = request.post_data or ""
+    for value in (TEST_NAME, TEST_EMAIL, TEST_MESSAGE):
+        assert value in post_data, f"Submitted payload is missing {value!r}"
+
+    logger.info("Contact form posts the payload to %s", request.url)
+
+
+@pytest.mark.ui
+def test_contact_form_surfaces_failure(page: Page) -> None:
+    """Test that a FormSubmit failure is shown to the user, not masked.
+
+    Canary for the response check: FormSubmit reports failures as
+    HTTP 200 with success "false", the exact shape that used to render
+    as false success in portfolio-site#82.
+
+    Args:
+        page: Playwright page fixture
+    """
+    logger.info("Testing that contact form failures are surfaced")
+
+    _submit_contact_form(page, FAILURE_BODY)
+
+    expect(page.get_by_text(FAILURE_MESSAGE_TEXT)).to_be_visible()
+    expect(page.get_by_text(SUCCESS_BANNER_TEXT)).not_to_be_visible()
+
+    logger.info("Contact form correctly surfaced the mocked failure")

--- a/tests/ui/test_contact_form.py
+++ b/tests/ui/test_contact_form.py
@@ -71,9 +71,7 @@ def test_contact_form_targets_formsubmit_ajax(page: Page) -> None:
 
     expect(page.get_by_text(SUCCESS_BANNER_TEXT)).to_be_visible()
 
-    assert len(requests) == 1, (
-        f"Expected exactly one FormSubmit request, saw {len(requests)}"
-    )
+    assert len(requests) == 1, f"Expected exactly one FormSubmit request, saw {len(requests)}"
     request = requests[0]
     assert request.method == "POST", f"Expected POST, got {request.method}"
     assert request.url.startswith(FORMSUBMIT_AJAX_PREFIX), (


### PR DESCRIPTION
Closes #49.

## Why

The contact form silently dropped every message for weeks (dardenkyle/portfolio-site#82) while this suite ran twice daily - the portfolio's single conversion path had zero coverage. With alerting now in place (#52), this adds the detection half.

## What

`tests/ui/test_contact_form.py`, two tests, FormSubmit fully mocked via `page.route` so **scheduled runs never send real email** (the issue's design decision - twice-daily real submissions would be ~60 test emails/month):

- **`test_contact_form_targets_formsubmit_ajax`**: intercepts everything toward `formsubmit.co`, submits the form, asserts exactly one POST to the `/ajax/` endpoint (the only one that processes fetch submissions) carrying the name/email/message payload, and that the success banner renders on a mocked success.
- **`test_contact_form_surfaces_failure`** (canary): fulfills the request with HTTP 200 + `{"success": "false"}` - the exact response shape that used to masquerade as success - and asserts the error state renders with no success banner.

## Detection proven against the real regression

Following the #27 lesson (a test that cannot fail is worthless), I rebuilt the pre-fix frontend from portfolio-site history (`e890514`), served it locally, and ran both tests against it:

- wiring test: **fails** with `Form posted to https://formsubmit.co/darden_kyle@hotmail.com; fetch submissions are only processed on the /ajax/ endpoint`
- failure-surfacing test: **fails** because the old code rendered false success

Against the live site: both pass; full suite 18/18; ruff and mypy clean.

## Known gap (accepted in #49)

Mocking covers the frontend wiring but not FormSubmit itself (e.g. alias deactivation). The issue left that as an option for a separate low-frequency real-submission job - not included here.