### PR TITLE
docs: align README and CONTRIBUTING with the restructured repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Site Sentry
 
-Thanks for checking out **Site Sentry** — a Playwright + Pytest QA suite.
+Thanks for checking out **Site Sentry** - a Playwright + Pytest QA suite.
 This guide keeps contributions consistent and the CI green.
 
 ---
@@ -11,30 +11,20 @@ This guide keeps contributions consistent and the CI green.
 # Python 3.12.13 (pinned in .python-version; uv provisions it automatically)
 uv sync
 uv run playwright install --with-deps chromium
-
-# “Pre-commit hooks are recommended for consistent formatting and linting. The CI pipeline enforces the same checks.”
-uv add --dev pre-commit
-uv run pre-commit install
-uv run pre-commit run --all-files
 ```
 
-If you have a Makefile:
-
-```bash
-make lint     # Ruff lint
-make fmt      # Ruff format
-make type     # mypy type check
-make test     # pytest (HTML/JUnit reports)
-```
-
-Without Makefile:
+Checks to run before committing (CI enforces the same ones):
 
 ```bash
 uv run ruff check .
 uv run ruff format .
 uv run mypy .
-uv run pytest -v --html=test-results/report.html --self-contained-html
+uv run pytest -v
 ```
+
+The HTML report is generated automatically (configured in `pyproject.toml`).
+Pre-commit hooks (#9) and Makefile shortcuts (#10) are planned but not yet
+available.
 
 ---
 
@@ -89,6 +79,7 @@ Closes #21
 - [ ] `mypy` passes
 - [ ] `pytest` passes locally
 - [ ] Docs updated if behavior changed
+- [ ] README structure trees updated if files were added, moved, or removed
 
 ### PR Expectations
 
@@ -104,9 +95,8 @@ Closes #21
 Artifacts:
 
 - HTML report: `test-results/report.html`
-- JUnit XML: `test-results/junit.xml`
-- Screenshots: `test-results/screenshots/`
-- Playwright traces: `test-results/playwright-traces/`
+- Screenshots on failure: `test-results/screenshots/`
+- JUnit XML output is planned (#12) but not yet generated
 
 Run locally:
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Automated QA suite for [kyledarden.com](https://kyledarden.com) built with Playw
 
 ## Features
 
-- 🎭 **Playwright-powered**: Modern, reliable browser automation
-- 🧪 **Comprehensive tests**: Smoke tests, UI validation, and navigation checks
-- 🐳 **Containerized**: Full Docker support for consistent environments
-- 🤖 **CI/CD ready**: Automated runs twice daily with GitHub Actions
-- 📊 **Rich reporting**: HTML test reports auto-generate with screenshots on failure
-- ⚡ **Fast & efficient**: Optimized for quick feedback (~2m 30s in CI)
-- 📦 **uv-managed**: Fast, modern Python dependency management with a committed lockfile
-- 📝 **Fully typed**: Type hints throughout for better IDE support
+- **Playwright-powered**: Modern, reliable browser automation
+- **Comprehensive tests**: Smoke tests, UI validation, and navigation checks
+- **Containerized**: Full Docker support for consistent environments
+- **CI/CD ready**: Automated runs twice daily with GitHub Actions
+- **Rich reporting**: HTML test reports auto-generate with screenshots on failure
+- **Fast & efficient**: Optimized for quick feedback (~2m 30s in CI)
+- **uv-managed**: Fast, modern Python dependency management with a committed lockfile
+- **Fully typed**: Type hints throughout for better IDE support
 
 ## Quick Start
 
@@ -83,11 +83,15 @@ docker run --rm -v $(pwd)/test-results:/app/test-results site-sentry
 
 ```
 tests/
-├── conftest.py           # Pytest configuration and fixtures
-├── test_smoke.py         # Critical smoke tests
-├── test_ui_nav.py        # UI and navigation tests
+├── conftest.py               # Pytest configuration and fixtures
+├── smoke/
+│   ├── test_config.py        # Configuration and environment checks
+│   └── test_smoke.py         # Critical smoke tests
+├── ui/
+│   ├── test_contact_form.py  # Contact form tests
+│   └── test_ui_nav.py        # UI and navigation tests
 └── utils/
-    └── logger.py         # Logging utilities
+    └── logger.py             # Logging utilities
 ```
 
 ### Test Categories
@@ -160,7 +164,7 @@ uv run ruff format --check tests/
 
 ### Adding New Tests
 
-1. Create test file in `tests/` directory (must start with `test_`)
+1. Create the test file in the matching category directory (`tests/smoke/`, `tests/ui/`); the filename must start with `test_`
 2. Add appropriate markers (`@pytest.mark.smoke`, `@pytest.mark.ui`, etc.)
 3. Use fixtures from `conftest.py` (page, context, base_url)
 4. Add type hints and docstrings
@@ -172,21 +176,27 @@ uv run ruff format --check tests/
 site-sentry/
 ├── .github/
 │   └── workflows/
-│       └── tests.yml        # CI/CD workflow
+│       ├── ci.yml               # Lint/type-check workflow
+│       └── tests.yml            # QA test workflow (push, PR, schedule)
 ├── tests/
 │   ├── __init__.py
-│   ├── conftest.py          # Pytest configuration
-│   ├── test_smoke.py        # Smoke tests
-│   ├── test_ui_nav.py       # UI/navigation tests
+│   ├── conftest.py              # Pytest configuration
+│   ├── smoke/                   # Smoke tests
+│   ├── ui/                      # UI/navigation tests
 │   └── utils/
 │       ├── __init__.py
-│       └── logger.py        # Logging utility
-├── .env.example             # Environment template
-├── .gitignore               # Git ignore rules
-├── Dockerfile               # Container definition
-├── LICENSE                  # MIT License
-├── pyproject.toml           # Project configuration
-└── README.md                # This file
+│       └── logger.py            # Logging utility
+├── .dockerignore                # Docker build exclusions
+├── .editorconfig                # Editor formatting rules
+├── .env.example                 # Environment template
+├── .gitignore                   # Git ignore rules
+├── .python-version              # Pinned Python version (uv)
+├── CONTRIBUTING.md              # Contribution guidelines
+├── Dockerfile                   # Container definition
+├── LICENSE                      # MIT License
+├── pyproject.toml               # Project configuration
+├── uv.lock                      # Locked dependency versions
+└── README.md                    # This file
 ```
 
 ## Contributing & Standards
@@ -194,8 +204,8 @@ site-sentry/
 This project follows consistent formatting and contribution standards:
 
 - Code style and indentation enforced via [`.editorconfig`](.editorconfig)
-- Linting, formatting, and type checks handled by **Ruff** and **mypy**
-- **Strongly recommended** to use **pre-commit hooks** to ensure all checks pass before committing
+- Linting, formatting, and type checks handled by **Ruff** and **mypy**, enforced in CI
+- Pre-commit hooks are planned (#9); until then, run the checks below before committing
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, commit style, and PR guidelines
 
 **Quick reference:**


### PR DESCRIPTION
Closes #34.

## Why

The test restructure (#23) moved tests into `tests/smoke/` and `tests/ui/`, but README and CONTRIBUTING still describe the old layout - the documented `pytest tests/test_smoke.py` fails, CONTRIBUTING sets up pre-commit hooks that have no config in the repo, and the promised `make` targets and JUnit output do not exist. Wrong docs in a resume repo are worse than missing docs.

## What

**README**
- Test Structure and Project Structure trees match the actual repository (restructured tests, `ci.yml`, previously unlisted root files).
- "Adding New Tests" points at the category directories.
- Emoji bullets removed from Features.
- Pre-commit hooks referenced as planned (#9) instead of recommended-but-nonexistent.

**CONTRIBUTING**
- Removed the pre-commit setup block (no `.pre-commit-config.yaml` in the repo) and the Makefile block (no Makefile; planned in #10); the real `uv run` commands remain.
- Dropped redundant `--html` pytest flags (already configured in `pyproject.toml`).
- Artifacts list corrected: HTML report and failure screenshots are real; JUnit XML marked planned (#12); Playwright traces removed.
- Smart quotes and the em dash replaced with plain characters.
- PR checklist gains: README structure trees must be updated when files are added, moved, or removed.

## Verification

On a fresh clone: `uv sync`, `uv run playwright install chromium`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy .`, `uv run pytest tests/smoke/test_smoke.py` (6 passed), and `uv run pytest -m smoke` (7 passed) all succeed, with the HTML report generated at the documented `test-results/report.html`. UI tests were not run locally to avoid exercising the production contact form; they are unaffected by this docs-only change.
