### PR TITLE
ci: retain Playwright traces on failure to capture the stalled request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           uv sync --locked
           uv run playwright install --with-deps chromium
       - name: Run tests
-        run: uv run pytest -v
+        run: uv run pytest -v --tracing retain-on-failure
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest -v
+          uv run pytest -v --tracing retain-on-failure
         continue-on-error: false
 
       - name: Upload test results


### PR DESCRIPTION
## Summary
Adds `--tracing retain-on-failure` to the pytest invocation in both workflows (`tests.yml` scheduled QA run and the `test` job in `ci.yml`), per the scope in #57. On any test failure, pytest-playwright writes a `trace.zip` for that test into `test-results/`, which both workflows already upload as artifacts with 30-day retention, so no artifact-step changes are needed.

## Why
Scheduled run #165 failed twice on 30s Playwright timeouts with a bimodal duration distribution, and the root cause cannot be separated by reasoning alone (stalling subresource vs. Render API vs. runner-side network). A trace from the failing moment contains the network waterfall that names the stalled request directly.

## Verification
Ran a deliberately failing test locally with the flag: it produced `test-results/<test-name>/trace.zip` (345 KB) containing a `trace.network` entry, confirming the trace lands inside the uploaded artifact path and carries network data. The conftest only extends `browser_type_launch_args`/`browser_context_args` and does not replace the plugin's `context` fixture, so the tracing implementation is not bypassed.

Closes #57