### PR TITLE
ci: gate the site-down incident on smoke failures and name the failing tests

### DIFF
--- a/.github/scripts/summarize_failures.py
+++ b/.github/scripts/summarize_failures.py
@@ -1,0 +1,80 @@
+"""Summarize pytest junit.xml results for the incident-alert job.
+
+Reads the junit report the scheduled QA run writes and prints GitHub
+Actions output lines (append stdout to $GITHUB_OUTPUT):
+
+    has_results=true|false   whether a junit report was found
+    failed_count=N           tests that failed or errored
+    smoke_failed=true|false  whether any failure was a smoke test
+    failed_tests<<EOF        one failing node id per line
+    ...
+    EOF
+
+The alert job uses smoke_failed to decide between a "Site down" and a
+"QA run failed" incident title, and failed_tests to make the incident
+issue self-describing without opening artifacts. Stdlib only.
+"""
+
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+JUNIT_PATH_ENV = "JUNIT_PATH"
+DEFAULT_JUNIT_PATH = "test-results/junit.xml"
+
+# pytest junit classnames are dotted module paths, e.g. tests.smoke.test_smoke
+SMOKE_CLASSNAME_PREFIX = "tests.smoke."
+
+OUTPUT_DELIMITER = "GHA_FAILED_TESTS_EOF"
+
+
+def collect_failures(junit_path: Path) -> tuple[list[str], bool] | None:
+    """Extract failing test ids and smoke involvement from a junit report.
+
+    A test counts as failing when its testcase carries a <failure> or
+    <error> child (errors cover collection/fixture crashes, which are
+    just as actionable as assertion failures).
+
+    Args:
+        junit_path: Path to the junit.xml report
+
+    Returns:
+        (failing test ids, any smoke test failed), or None when the
+        report does not exist (the run died before pytest could write it)
+    """
+    result: tuple[list[str], bool] | None = None
+    if junit_path.exists():
+        root = ET.parse(junit_path).getroot()
+        failing: list[str] = []
+        smoke_failed = False
+        for case in root.iter("testcase"):
+            broken = case.find("failure") is not None or case.find("error") is not None
+            if broken:
+                classname = case.get("classname") or ""
+                name = case.get("name") or ""
+                failing.append(f"{classname}::{name}")
+                smoke_failed = smoke_failed or classname.startswith(SMOKE_CLASSNAME_PREFIX)
+        result = (failing, smoke_failed)
+    return result
+
+
+def main() -> None:
+    """Print the failure summary as GitHub Actions output lines.
+
+    The output format is defined in the module docstring. The junit
+    report location can be overridden via the JUNIT_PATH env var.
+    """
+    junit_path = Path(os.getenv(JUNIT_PATH_ENV, DEFAULT_JUNIT_PATH))
+    summary = collect_failures(junit_path)
+    failing, smoke_failed = summary if summary is not None else ([], False)
+    print(f"has_results={'true' if summary is not None else 'false'}")
+    print(f"failed_count={len(failing)}")
+    print(f"smoke_failed={'true' if smoke_failed else 'false'}")
+    print(f"failed_tests<<{OUTPUT_DELIMITER}")
+    for node_id in failing:
+        print(node_id)
+    print(OUTPUT_DELIMITER)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/summarize_failures.py
+++ b/.github/scripts/summarize_failures.py
@@ -3,10 +3,10 @@
 Reads the junit report the scheduled QA run writes and prints GitHub
 Actions output lines (append stdout to $GITHUB_OUTPUT):
 
-    has_results=true|false   whether a junit report was found
+    has_results=true|false   whether a junit report was found and parsed
     failed_count=N           tests that failed or errored
     smoke_failed=true|false  whether any failure was a smoke test
-    failed_tests<<EOF        one failing node id per line
+    failed_tests<<EOF        one failing test node id per line
     ...
     EOF
 
@@ -28,6 +28,30 @@ SMOKE_CLASSNAME_PREFIX = "tests.smoke."
 OUTPUT_DELIMITER = "GHA_FAILED_TESTS_EOF"
 
 
+def to_node_id(classname: str, name: str) -> str:
+    """Reconstruct a pytest node id from junit classname and test name.
+
+    pytest's default xunit2 junit output carries no file attribute, so
+    the module path is rebuilt from the dotted classname (e.g.
+    tests.smoke.test_smoke -> tests/smoke/test_smoke.py). When the
+    rebuilt file does not exist (class-based tests, or running outside
+    the repo root), falls back to the raw classname::name form.
+
+    Args:
+        classname: Dotted module path from the junit testcase
+        name: Test name from the junit testcase, including parameters
+
+    Returns:
+        A runnable pytest node id, or classname::name as best effort
+    """
+    module_path = Path(classname.replace(".", "/") + ".py")
+    if classname and module_path.exists():
+        node_id = f"{module_path}::{name}"
+    else:
+        node_id = f"{classname}::{name}"
+    return node_id
+
+
 def collect_failures(junit_path: Path) -> tuple[list[str], bool] | None:
     """Extract failing test ids and smoke involvement from a junit report.
 
@@ -39,12 +63,16 @@ def collect_failures(junit_path: Path) -> tuple[list[str], bool] | None:
         junit_path: Path to the junit.xml report
 
     Returns:
-        (failing test ids, any smoke test failed), or None when the
-        report does not exist (the run died before pytest could write it)
+        (failing test node ids, any smoke test failed), or None when the
+        report is missing, unreadable, or malformed - all of which mean
+        the run died before pytest could write it completely
     """
+    try:
+        root: ET.Element | None = ET.parse(junit_path).getroot()
+    except (OSError, ET.ParseError):
+        root = None
     result: tuple[list[str], bool] | None = None
-    if junit_path.exists():
-        root = ET.parse(junit_path).getroot()
+    if root is not None:
         failing: list[str] = []
         smoke_failed = False
         for case in root.iter("testcase"):
@@ -52,7 +80,7 @@ def collect_failures(junit_path: Path) -> tuple[list[str], bool] | None:
             if broken:
                 classname = case.get("classname") or ""
                 name = case.get("name") or ""
-                failing.append(f"{classname}::{name}")
+                failing.append(to_node_id(classname, name))
                 smoke_failed = smoke_failed or classname.startswith(SMOKE_CLASSNAME_PREFIX)
         result = (failing, smoke_failed)
     return result

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,13 @@ jobs:
     name: Run QA Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Consumed by the alert job to pick incident severity and name the
+    # failing tests; populated from junit.xml even when this job fails
+    outputs:
+      has_results: ${{ steps.failures.outputs.has_results }}
+      failed_count: ${{ steps.failures.outputs.failed_count }}
+      smoke_failed: ${{ steps.failures.outputs.smoke_failed }}
+      failed_tests: ${{ steps.failures.outputs.failed_tests }}
 
     steps:
       - name: Checkout repository
@@ -34,8 +41,13 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest -v --tracing retain-on-failure
+          uv run pytest -v --tracing retain-on-failure --junitxml=test-results/junit.xml
         continue-on-error: false
+
+      - name: Summarize failures for the alert job
+        id: failures
+        if: always()
+        run: uv run python .github/scripts/summarize_failures.py >> "$GITHUB_OUTPUT"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -74,26 +86,55 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       TEST_RESULT: ${{ needs.test.result }}
+      HAS_RESULTS: ${{ needs.test.outputs.has_results }}
+      FAILED_COUNT: ${{ needs.test.outputs.failed_count }}
+      SMOKE_FAILED: ${{ needs.test.outputs.smoke_failed }}
+      FAILED_TESTS: ${{ needs.test.outputs.failed_tests }}
     steps:
+      # "Site down" is reserved for smoke-test failures; anything else is
+      # reported as what it is (failing QA tests, or a run that produced
+      # no results at all). The site-down label is the incident marker
+      # for the open/comment/close lifecycle regardless of severity.
       - name: Open or update incident issue
         if: needs.test.result != 'success'
         run: |
+          if [ "$SMOKE_FAILED" = "true" ]; then
+            title="Site down: scheduled smoke tests failing"
+            assessment="Smoke tests against the live site failed, so the site is likely down or broken."
+          elif [ "$HAS_RESULTS" = "true" ] && [ "${FAILED_COUNT:-0}" -gt 0 ]; then
+            title="QA run failed: $FAILED_COUNT test(s) failing"
+            assessment="Smoke tests passed; the failures are in non-smoke tests, so the site itself is likely up."
+          else
+            title="QA run failed: no test results produced (result: $TEST_RESULT)"
+            assessment="The run ended without a test report (setup failure, timeout, or cancellation), so site status is unknown."
+          fi
+          if [ -n "$FAILED_TESTS" ]; then
+            failing=$(printf '%s\n' "$FAILED_TESTS" | sed 's/^/- `/; s/$/`/')
+          else
+            failing="- (no per-test results available)"
+          fi
+          details="$assessment
+
+          Failing tests:
+          $failing
+
+          - Run: $RUN_URL
+          - The \`html-report\` and \`test-results\` artifacts on the run have per-test details and Playwright traces."
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
             --label site-down --state open \
             --json number --jq '.[0].number // empty')
           if [ -z "$existing" ]; then
             gh issue create --repo "$GITHUB_REPOSITORY" \
-              --title "Site down: scheduled QA run did not succeed" \
+              --title "$title" \
               --label site-down \
-              --body "The scheduled QA run against the live site did not succeed (result: $TEST_RESULT).
-
-          - Run: $RUN_URL
-          - The \`html-report\` artifact on the run has per-test details.
+              --body "$details
 
           This issue is managed automatically: further unsuccessful scheduled runs add comments here, and the next passing scheduled run closes it."
           else
             gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
-              --body "Still not passing (result: $TEST_RESULT): $RUN_URL"
+              --body "Still failing: $title
+
+          $details"
           fi
 
       - name: Close incident issue on recovery


### PR DESCRIPTION
## Summary
Implements #59. The scheduled QA run now writes `test-results/junit.xml`, a stdlib parser (`.github/scripts/summarize_failures.py`) converts it into job outputs (`has_results`, `failed_count`, `smoke_failed`, `failed_tests`), and the alert job picks incident severity from those instead of the blanket job result:

- **`Site down: scheduled smoke tests failing`** - only when a `tests/smoke` test failed or errored
- **`QA run failed: N test(s) failing`** - smoke passed, other tests failed (run #165's situation, which mislabeled a flaky UI test as downtime in #56)
- **`QA run failed: no test results produced (result: ...)`** - the run died before pytest wrote a report (setup failure, timeout, cancellation)

The issue body and follow-up comments list the failing node ids, so triage no longer requires downloading artifacts. `junit.xml` lands in `test-results/` and is uploaded with the existing artifact step.

## Preserved properties
- `site-down` label remains the incident marker, keeping the single-issue open/comment/close lifecycle intact
- `concurrency: site-down-incident` group unchanged
- `github.event_name == 'schedule'` gate unchanged (manual re-runs never touch incidents)
- Recovery close step untouched

## Verification
- Parser exercised against real pytest junit output for three cases: smoke-passes/non-smoke-fails (`smoke_failed=false`, correct node id), smoke failure via unreachable BASE_URL (`smoke_failed=true`), and missing report (`has_results=false`)
- Alert step's title/body logic dry-run for all three branches with stubbed `gh`; output matches the acceptance criteria
- `ruff`, `ruff format --check`, and `mypy` (run explicitly on the script, since mypy skips dot-directories) all clean; workflow YAML parses

Closes #59