### PR TITLE
test: fix inverted performance thresholds (deliberate first/warm budgets)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from playwright.sync_api import Browser
 from playwright.sync_api import Error as PlaywrightError
 
 from tests.utils.logger import get_logger
-from tests.utils.timing import ColdNavigation
+from tests.utils.timing import FirstNavigation
 
 # Create test-results directory immediately when conftest is imported
 TEST_RESULTS_DIR = Path(__file__).parent.parent / "test-results"
@@ -29,10 +29,10 @@ TEST_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 SLOW_TEST_THRESHOLD_SECONDS = 5.0
 
 # Ceiling for the session's first navigation. Deliberately above the
-# cold budget the test asserts, so a slow-but-completing load is
-# reported as a measured number instead of a bare timeout, and well
-# below the 30s Playwright default this replaces.
-COLD_NAVIGATION_TIMEOUT_MS = 20_000
+# budget the test asserts, so a slow-but-completing load is reported as
+# a measured number instead of a bare timeout, and well below the 30s
+# Playwright default this replaces.
+FIRST_NAVIGATION_TIMEOUT_MS = 20_000
 
 # Call-phase durations per test nodeid, collected across the session
 _test_durations: dict[str, float] = {}
@@ -44,14 +44,19 @@ logger = get_logger(__name__)
 
 
 @pytest.fixture(scope="session", autouse=True)
-def cold_navigation(browser: Browser, base_url: str) -> ColdNavigation:
+def first_navigation(browser: Browser, base_url: str) -> FirstNavigation:
     """Measure the session's first navigation to the site under test.
 
-    Warm navigations reuse DNS, TCP, and TLS state, so a latency budget
-    asserted mid-suite cannot see the cold-path cost that a real first
-    visitor pays. This runs before any test (autouse, session scope) in
-    its own context, so exactly one navigation in the session is cold
-    and it is this one.
+    Runs before any test (autouse, session scope) in its own context, so
+    this is the one navigation taken before the suite has warmed
+    anything it can warm: connection setup (DNS, TCP, TLS) has not yet
+    happened in this process. Every later timing reuses that state.
+
+    This is deliberately not a cache-cold measurement. The site sits
+    behind a CDN whose edge cache is warm regardless of what the suite
+    does, and pytest-playwright already gives every test a fresh context
+    with an empty browser cache, so cache state is not what sets this
+    navigation apart. Connection setup is.
 
     Navigation failures are captured rather than raised: raising here
     would error every test in the session and misreport a single slow
@@ -70,13 +75,13 @@ def cold_navigation(browser: Browser, base_url: str) -> ColdNavigation:
     error: str | None = None
     start = time.perf_counter()
     try:
-        page.goto("/", wait_until="load", timeout=COLD_NAVIGATION_TIMEOUT_MS)
+        page.goto("/", wait_until="load", timeout=FIRST_NAVIGATION_TIMEOUT_MS)
     except PlaywrightError as exc:
         error = exc.message
     seconds = time.perf_counter() - start
     context.close()
-    logger.info("Cold navigation took %.2fs (error: %s)", seconds, error)
-    return ColdNavigation(seconds=seconds, error=error)
+    logger.info("First navigation took %.2fs (error: %s)", seconds, error)
+    return FirstNavigation(seconds=seconds, error=error)
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,11 +15,15 @@ from typing import Any
 
 import pytest
 from dotenv import load_dotenv
-from playwright.sync_api import Browser
+from playwright.sync_api import Browser, Page
 from playwright.sync_api import Error as PlaywrightError
 
 from tests.utils.logger import get_logger
-from tests.utils.timing import FirstNavigation
+from tests.utils.timing import (
+    FIRST_NAVIGATION_TIMEOUT_MS,
+    PAGE_LOAD_TIMEOUT_MS,
+    FirstNavigation,
+)
 
 # Create test-results directory immediately when conftest is imported
 TEST_RESULTS_DIR = Path(__file__).parent.parent / "test-results"
@@ -28,12 +32,6 @@ TEST_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 # Tests slower than this count toward slow_count in durations.json
 SLOW_TEST_THRESHOLD_SECONDS = 5.0
 
-# Ceiling for the session's first navigation. Deliberately above the
-# budget the test asserts, so a slow-but-completing load is reported as
-# a measured number instead of a bare timeout, and well below the 30s
-# Playwright default this replaces.
-FIRST_NAVIGATION_TIMEOUT_MS = 20_000
-
 # Call-phase durations per test nodeid, collected across the session
 _test_durations: dict[str, float] = {}
 
@@ -41,6 +39,25 @@ _test_durations: dict[str, float] = {}
 load_dotenv()
 
 logger = get_logger(__name__)
+
+
+@pytest.fixture
+def page(page: Page) -> Page:
+    """Apply the suite's deliberate navigation timeout to every page.
+
+    Without this, each page.goto inherits Playwright's implicit 30s
+    default, which is how an unchosen value became the de facto
+    performance gate. Setting it here rather than per call site means a
+    new test cannot silently opt back into the default.
+
+    Args:
+        page: The plugin's built-in page fixture
+
+    Returns:
+        The same page with an explicit navigation timeout applied
+    """
+    page.set_default_navigation_timeout(PAGE_LOAD_TIMEOUT_MS)
+    return page
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -71,15 +88,16 @@ def first_navigation(browser: Browser, base_url: str) -> FirstNavigation:
         Elapsed seconds and any navigation error
     """
     context = browser.new_context(base_url=base_url)
-    page = context.new_page()
     error: str | None = None
     start = time.perf_counter()
     try:
+        page = context.new_page()
         page.goto("/", wait_until="load", timeout=FIRST_NAVIGATION_TIMEOUT_MS)
     except PlaywrightError as exc:
-        error = exc.message
-    seconds = time.perf_counter() - start
-    context.close()
+        error = str(exc)
+    finally:
+        seconds = time.perf_counter() - start
+        context.close()
     logger.info("First navigation took %.2fs (error: %s)", seconds, error)
     return FirstNavigation(seconds=seconds, error=error)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ configuration management, and test utilities.
 import json
 import os
 import statistics
+import time
 from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -14,8 +15,11 @@ from typing import Any
 
 import pytest
 from dotenv import load_dotenv
+from playwright.sync_api import Browser
+from playwright.sync_api import Error as PlaywrightError
 
 from tests.utils.logger import get_logger
+from tests.utils.timing import ColdNavigation
 
 # Create test-results directory immediately when conftest is imported
 TEST_RESULTS_DIR = Path(__file__).parent.parent / "test-results"
@@ -24,6 +28,12 @@ TEST_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 # Tests slower than this count toward slow_count in durations.json
 SLOW_TEST_THRESHOLD_SECONDS = 5.0
 
+# Ceiling for the session's first navigation. Deliberately above the
+# cold budget the test asserts, so a slow-but-completing load is
+# reported as a measured number instead of a bare timeout, and well
+# below the 30s Playwright default this replaces.
+COLD_NAVIGATION_TIMEOUT_MS = 20_000
+
 # Call-phase durations per test nodeid, collected across the session
 _test_durations: dict[str, float] = {}
 
@@ -31,6 +41,42 @@ _test_durations: dict[str, float] = {}
 load_dotenv()
 
 logger = get_logger(__name__)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cold_navigation(browser: Browser, base_url: str) -> ColdNavigation:
+    """Measure the session's first navigation to the site under test.
+
+    Warm navigations reuse DNS, TCP, and TLS state, so a latency budget
+    asserted mid-suite cannot see the cold-path cost that a real first
+    visitor pays. This runs before any test (autouse, session scope) in
+    its own context, so exactly one navigation in the session is cold
+    and it is this one.
+
+    Navigation failures are captured rather than raised: raising here
+    would error every test in the session and misreport a single slow
+    request as a total outage. The smoke test that consumes this decides
+    what the numbers mean.
+
+    Args:
+        browser: Session-scoped Playwright browser from pytest-playwright
+        base_url: Base URL of the site under test
+
+    Returns:
+        Elapsed seconds and any navigation error
+    """
+    context = browser.new_context(base_url=base_url)
+    page = context.new_page()
+    error: str | None = None
+    start = time.perf_counter()
+    try:
+        page.goto("/", wait_until="load", timeout=COLD_NAVIGATION_TIMEOUT_MS)
+    except PlaywrightError as exc:
+        error = exc.message
+    seconds = time.perf_counter() - start
+    context.close()
+    logger.info("Cold navigation took %.2fs (error: %s)", seconds, error)
+    return ColdNavigation(seconds=seconds, error=error)
 
 
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -11,7 +11,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from tests.utils.logger import get_logger
-from tests.utils.timing import ColdNavigation
+from tests.utils.timing import FirstNavigation
 
 logger = get_logger(__name__)
 
@@ -22,10 +22,11 @@ logger = get_logger(__name__)
 PAGE_LOAD_TIMEOUT_MS = 15_000
 
 # Latency budget for the session's first navigation, which pays DNS,
-# TCP, and TLS setup on top of the request itself.
-COLD_LOAD_BUDGET_SECONDS = 10.0
+# TCP, and TLS setup on top of the request itself. Not a cache-cold
+# budget: the CDN edge cache is warm regardless of what the suite does.
+FIRST_NAVIGATION_BUDGET_SECONDS = 10.0
 
-# Latency budget once connection and CDN state are warm.
+# Latency budget once connection state is established by earlier tests.
 WARM_LOAD_BUDGET_SECONDS = 5.0
 
 
@@ -95,24 +96,25 @@ def test_no_console_errors(page: Page) -> None:
 
 
 @pytest.mark.smoke
-def test_cold_navigation_response_time(cold_navigation: ColdNavigation) -> None:
-    """Test the session's first navigation against the cold-path budget.
+def test_first_navigation_response_time(first_navigation: FirstNavigation) -> None:
+    """Test the session's first navigation against its latency budget.
 
     Consumes the session-scoped measurement taken before any other test
-    ran, so this is the one navigation that paid DNS, TCP, and TLS
-    setup. Every other timing in the suite is warm by comparison.
+    ran, so this is the one navigation that paid connection setup (DNS,
+    TCP, TLS) in this process. Every other timing in the suite reuses
+    that state, which is what makes this the looser of the two budgets.
 
     Args:
-        cold_navigation: Session-scoped first-navigation measurement
+        first_navigation: Session-scoped first-navigation measurement
     """
-    logger.info("Cold navigation took %.2fs", cold_navigation.seconds)
+    logger.info("First navigation took %.2fs", first_navigation.seconds)
 
-    assert cold_navigation.error is None, (
-        f"First navigation failed after {cold_navigation.seconds:.2f}s: {cold_navigation.error}"
+    assert first_navigation.error is None, (
+        f"First navigation failed after {first_navigation.seconds:.2f}s: {first_navigation.error}"
     )
-    assert cold_navigation.seconds < COLD_LOAD_BUDGET_SECONDS, (
-        f"First navigation took {cold_navigation.seconds:.2f}s "
-        f"(budget {COLD_LOAD_BUDGET_SECONDS:.0f}s)"
+    assert first_navigation.seconds < FIRST_NAVIGATION_BUDGET_SECONDS, (
+        f"First navigation took {first_navigation.seconds:.2f}s "
+        f"(budget {FIRST_NAVIGATION_BUDGET_SECONDS:.0f}s)"
     )
 
 
@@ -120,9 +122,9 @@ def test_cold_navigation_response_time(cold_navigation: ColdNavigation) -> None:
 def test_warm_response_time(page: Page) -> None:
     """Test that a warm navigation stays within the warm-path budget.
 
-    Runs mid-suite with connection and CDN state already warm, so this
-    is deliberately the tighter budget of the two: it catches steady
-    latency regressions, not the cold-path cost a first visitor pays.
+    Runs mid-suite with connection state already established, so this is
+    deliberately the tighter budget of the two: it catches steady
+    latency regressions, not the one-time connection setup cost.
 
     Args:
         page: Playwright page fixture

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -4,26 +4,46 @@ Fast, critical tests that verify core functionality and site availability.
 These tests should run quickly and catch major breakages.
 """
 
+import time
 from typing import Any
 
 import pytest
 from playwright.sync_api import Page, expect
 
 from tests.utils.logger import get_logger
+from tests.utils.timing import ColdNavigation
 
 logger = get_logger(__name__)
+
+# Availability ceiling for a warm navigation. Chosen deliberately to
+# replace the implicit 30s Playwright default that previously acted as
+# the de facto performance gate: warm loads are consistently sub-second,
+# so 15s is failure territory, not slowness.
+PAGE_LOAD_TIMEOUT_MS = 15_000
+
+# Latency budget for the session's first navigation, which pays DNS,
+# TCP, and TLS setup on top of the request itself.
+COLD_LOAD_BUDGET_SECONDS = 10.0
+
+# Latency budget once connection and CDN state are warm.
+WARM_LOAD_BUDGET_SECONDS = 5.0
 
 
 @pytest.mark.smoke
 def test_homepage_loads(page: Page) -> None:
-    """Test that the homepage loads successfully.
+    """Test that the homepage is reachable and returns a healthy status.
+
+    This is the availability check, not the performance gate: it asks
+    only whether the page loaded. The explicit timeout is a deliberate
+    ceiling on "never arrived", and the latency budgets live in the
+    response-time tests so a failure names which property broke.
 
     Args:
         page: Playwright page fixture
     """
     logger.info("Testing homepage load")
 
-    response = page.goto("/")
+    response = page.goto("/", timeout=PAGE_LOAD_TIMEOUT_MS)
     assert response is not None, "No response received"
     assert response.ok, f"Response not OK: {response.status}"
 
@@ -75,24 +95,48 @@ def test_no_console_errors(page: Page) -> None:
 
 
 @pytest.mark.smoke
-def test_response_time(page: Page) -> None:
-    """Test that the homepage loads within acceptable time.
+def test_cold_navigation_response_time(cold_navigation: ColdNavigation) -> None:
+    """Test the session's first navigation against the cold-path budget.
+
+    Consumes the session-scoped measurement taken before any other test
+    ran, so this is the one navigation that paid DNS, TCP, and TLS
+    setup. Every other timing in the suite is warm by comparison.
+
+    Args:
+        cold_navigation: Session-scoped first-navigation measurement
+    """
+    logger.info("Cold navigation took %.2fs", cold_navigation.seconds)
+
+    assert cold_navigation.error is None, (
+        f"First navigation failed after {cold_navigation.seconds:.2f}s: {cold_navigation.error}"
+    )
+    assert cold_navigation.seconds < COLD_LOAD_BUDGET_SECONDS, (
+        f"First navigation took {cold_navigation.seconds:.2f}s "
+        f"(budget {COLD_LOAD_BUDGET_SECONDS:.0f}s)"
+    )
+
+
+@pytest.mark.smoke
+def test_warm_response_time(page: Page) -> None:
+    """Test that a warm navigation stays within the warm-path budget.
+
+    Runs mid-suite with connection and CDN state already warm, so this
+    is deliberately the tighter budget of the two: it catches steady
+    latency regressions, not the cold-path cost a first visitor pays.
 
     Args:
         page: Playwright page fixture
     """
-    logger.info("Testing page load time")
+    logger.info("Testing warm page load time")
 
-    import time
-
-    start_time = time.time()
-
-    response = page.goto("/", wait_until="load")
-
-    load_time = time.time() - start_time
+    start_time = time.perf_counter()
+    response = page.goto("/", wait_until="load", timeout=PAGE_LOAD_TIMEOUT_MS)
+    load_time = time.perf_counter() - start_time
 
     assert response is not None, "No response received"
-    assert load_time < 5.0, f"Page took {load_time:.2f}s to load (expected < 5s)"
+    assert load_time < WARM_LOAD_BUDGET_SECONDS, (
+        f"Warm navigation took {load_time:.2f}s (budget {WARM_LOAD_BUDGET_SECONDS:.0f}s)"
+    )
 
     logger.info("Page loaded in %.2fs", load_time)
 

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -11,15 +11,9 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from tests.utils.logger import get_logger
-from tests.utils.timing import FirstNavigation
+from tests.utils.timing import PAGE_LOAD_TIMEOUT_MS, FirstNavigation
 
 logger = get_logger(__name__)
-
-# Availability ceiling for a warm navigation. Chosen deliberately to
-# replace the implicit 30s Playwright default that previously acted as
-# the de facto performance gate: warm loads are consistently sub-second,
-# so 15s is failure territory, not slowness.
-PAGE_LOAD_TIMEOUT_MS = 15_000
 
 # Latency budget for the session's first navigation, which pays DNS,
 # TCP, and TLS setup on top of the request itself. Not a cache-cold
@@ -35,16 +29,17 @@ def test_homepage_loads(page: Page) -> None:
     """Test that the homepage is reachable and returns a healthy status.
 
     This is the availability check, not the performance gate: it asks
-    only whether the page loaded. The explicit timeout is a deliberate
-    ceiling on "never arrived", and the latency budgets live in the
-    response-time tests so a failure names which property broke.
+    only whether the page loaded. The page fixture applies the suite's
+    deliberate PAGE_LOAD_TIMEOUT_MS ceiling on "never arrived", and the
+    latency budgets live in the response-time tests, so a failure names
+    which property broke.
 
     Args:
         page: Playwright page fixture
     """
-    logger.info("Testing homepage load")
+    logger.info("Testing homepage load (ceiling %dms)", PAGE_LOAD_TIMEOUT_MS)
 
-    response = page.goto("/", timeout=PAGE_LOAD_TIMEOUT_MS)
+    response = page.goto("/")
     assert response is not None, "No response received"
     assert response.ok, f"Response not OK: {response.status}"
 
@@ -132,7 +127,7 @@ def test_warm_response_time(page: Page) -> None:
     logger.info("Testing warm page load time")
 
     start_time = time.perf_counter()
-    response = page.goto("/", wait_until="load", timeout=PAGE_LOAD_TIMEOUT_MS)
+    response = page.goto("/", wait_until="load")
     load_time = time.perf_counter() - start_time
 
     assert response is not None, "No response received"

--- a/tests/utils/timing.py
+++ b/tests/utils/timing.py
@@ -7,7 +7,7 @@ a conftest module, which pytest may load under more than one module name.
 from typing import NamedTuple
 
 
-class ColdNavigation(NamedTuple):
+class FirstNavigation(NamedTuple):
     """Outcome of the first navigation performed in a test session.
 
     Attributes:

--- a/tests/utils/timing.py
+++ b/tests/utils/timing.py
@@ -1,0 +1,19 @@
+"""Shared timing types for Site Sentry tests.
+
+Lives outside conftest.py so tests can import the type without importing
+a conftest module, which pytest may load under more than one module name.
+"""
+
+from typing import NamedTuple
+
+
+class ColdNavigation(NamedTuple):
+    """Outcome of the first navigation performed in a test session.
+
+    Attributes:
+        seconds: Wall-clock time spent in the navigation
+        error: Playwright error message, or None when it completed
+    """
+
+    seconds: float
+    error: str | None

--- a/tests/utils/timing.py
+++ b/tests/utils/timing.py
@@ -1,10 +1,22 @@
-"""Shared timing types for Site Sentry tests.
+"""Shared timing configuration and types for Site Sentry tests.
 
-Lives outside conftest.py so tests can import the type without importing
-a conftest module, which pytest may load under more than one module name.
+Lives outside conftest.py so tests can import these without importing a
+conftest module, which pytest may load under more than one module name.
 """
 
 from typing import NamedTuple
+
+# Deliberate ceiling on every navigation in the suite, applied by the
+# page fixture in conftest.py. Replaces Playwright's implicit 30s
+# default, which previously acted as an unchosen performance gate:
+# navigations here are consistently sub-second, so 15s is failure
+# territory rather than slowness.
+PAGE_LOAD_TIMEOUT_MS = 15_000
+
+# Ceiling for the session's first navigation. Deliberately above the
+# budget the test asserts, so a slow-but-completing load is reported as
+# a measured number instead of a bare timeout.
+FIRST_NAVIGATION_TIMEOUT_MS = 20_000
 
 
 class FirstNavigation(NamedTuple):


### PR DESCRIPTION
## Summary
Implements #60. The thresholds were inverted: `test_response_time` asserted `< 5s` but ran mid-suite on warm connection state (292ms in run #165, the same run where another request took 45s), while `test_homepage_loads` was the de facto performance gate through an implicit, never-chosen 30s `page.goto` default. All three options in the issue scope are implemented, since they address different axes of the same problem.

### First-navigation measurement
A session-scoped **autouse** `first_navigation` fixture navigates once in its own context before any test runs, so it is the one navigation taken before the suite establishes connection state (DNS, TCP, TLS). Navigation errors are **captured, not raised** - raising in a session fixture would error all 19 tests and misreport a single slow request as a total outage, which is precisely the mislabeling #59 just fixed on the alerting side.

**This is deliberately not a cache-cold measurement**, and the naming and docstrings now say so. The site sits behind a CDN whose edge cache is warm regardless of what the suite does (the #57 investigation measured cache-busted TTFB at 42ms and ruled the CDN out), and pytest-playwright already gives every test a fresh context with an empty browser cache. Cache state is not what sets this navigation apart; connection setup is. An earlier revision of this PR called it `cold_navigation`, which overclaimed - renamed in e9ba495.

### Explicit gates
| Constant | Value | Replaces |
|---|---|---|
| `PAGE_LOAD_TIMEOUT_MS` | 15s | implicit 30s Playwright default |
| `FIRST_NAVIGATION_BUDGET_SECONDS` | 10s | nothing (new first-navigation path) |
| `WARM_LOAD_BUDGET_SECONDS` | 5s | the old warm 5s assertion |

`FIRST_NAVIGATION_TIMEOUT_MS` (20s) sits deliberately above the 10s budget so a slow-but-completing load is reported as a measured number rather than a bare timeout.

### Split load from speed
`test_homepage_loads` now asserts only reachability with an explicit timeout; `test_response_time` became `test_warm_response_time`. A failure now names whether availability or latency broke.

## Verification
- Full suite 19 passed; `-m smoke` (the Docker job's path) 8 passed
- **Ordering proven**: with `-s`, the fixture logs `First navigation took 0.30s` before `test_homepage_loads` logs its first navigation
- **Failure isolation proven**: with `BASE_URL=http://127.0.0.1:9`, the first-navigation test fails with `First navigation failed after 0.01s: ...ERR_UNSAFE_PORT` while a sibling test still passes - 1 failed, 1 passed, no session errors
- **Budget path proven**: temporarily lowering the budget produced `First navigation took 0.36s (budget 0s)`, confirming it reports the measured value; constant reverted
- `ruff`, `ruff format --check`, `mypy` clean

## Note
`test_response_time` -> `test_warm_response_time` and the new first-navigation test change node ids, so the #58 duration trend restarts for those two entries.

Closes #60
