### PR TITLE
test: scoped smoke retries that cannot hide the stall they absorb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pytest-playwright>=0.5.0",
     "playwright>=1.40.0",
     "python-dotenv>=1.0.0",
+    "pytest-rerunfailures>=14.0",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,9 +118,10 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     they cannot silently extend to the UI suite, where a rerun would
     mask a real regression instead of a transient network stall.
 
-    Tests marked no_rerun are skipped: a test whose verdict comes from a
-    session-scoped measurement re-reads the same cached value on every
-    attempt, so retrying it only burns the rerun delay.
+    Tests marked no_rerun still run normally, they just do not receive
+    the retry marker: a test whose verdict comes from a session-scoped
+    measurement re-reads the same cached value on every attempt, so
+    retrying it only burns the rerun delay.
 
     Args:
         items: Collected test items, mutated in place

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,17 @@ TEST_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 # Tests slower than this count toward slow_count in durations.json
 SLOW_TEST_THRESHOLD_SECONDS = 5.0
 
-# Call-phase durations per test nodeid, collected across the session
-_test_durations: dict[str, float] = {}
+# Retry budget for smoke tests, which run against a live site and can
+# lose a request to a transient stall. Scoped to smoke deliberately:
+# retries buy noise reduction by discarding evidence, which is only
+# worth it for the availability signal that gates incident alerts.
+SMOKE_RERUNS = 2
+SMOKE_RERUN_DELAY_SECONDS = 5
+
+# Call-phase duration and outcome per attempt, keyed by test nodeid.
+# A retried test appends rather than overwrites, so the slow attempt
+# that triggered the retry survives into durations.json.
+_test_durations: dict[str, list[tuple[float, str]]] = {}
 
 # Load environment variables
 load_dotenv()
@@ -102,18 +111,40 @@ def first_navigation(browser: Browser, base_url: str) -> FirstNavigation:
     return FirstNavigation(seconds=seconds, error=error)
 
 
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Grant smoke tests a retry budget, and nothing else.
+
+    Retries are applied here rather than via a global --reruns flag so
+    they cannot silently extend to the UI suite, where a rerun would
+    mask a real regression instead of a transient network stall.
+
+    Tests marked no_rerun are skipped: a test whose verdict comes from a
+    session-scoped measurement re-reads the same cached value on every
+    attempt, so retrying it only burns the rerun delay.
+
+    Args:
+        items: Collected test items, mutated in place
+    """
+    retry = pytest.mark.flaky(reruns=SMOKE_RERUNS, reruns_delay=SMOKE_RERUN_DELAY_SECONDS)
+    for item in items:
+        if item.get_closest_marker("smoke") and not item.get_closest_marker("no_rerun"):
+            item.add_marker(retry)
+
+
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
-    """Record the call-phase duration of every test.
+    """Record the call-phase duration and outcome of every attempt.
 
     Setup and teardown phases are excluded so the numbers reflect what
     the test itself did (navigation, requests, assertions), not fixture
-    overhead. Durations feed durations.json at session end.
+    overhead. Attempts append rather than overwrite: a retried test
+    would otherwise report only its fast passing attempt, hiding the
+    stall that caused the retry. Durations feed durations.json.
 
     Args:
-        report: Per-phase report emitted by pytest for each test
+        report: Per-phase report emitted by pytest for each attempt
     """
     if report.when == "call":
-        _test_durations[report.nodeid] = report.duration
+        _test_durations.setdefault(report.nodeid, []).append((report.duration, report.outcome))
 
 
 def _write_durations_file() -> None:
@@ -124,8 +155,22 @@ def _write_durations_file() -> None:
     because pass/fail discards timing. This persists per-test durations
     plus aggregates every run, so drift shows up as a trend in the
     uploaded artifacts weeks before it trips timeouts. Stdlib only.
+
+    Per-test durations report the slowest attempt, not the last one, so
+    a stall that a retry papered over still lands in the file and in the
+    aggregates. Every attempt of a retried test is preserved in full
+    under "retried".
     """
-    durations = sorted(_test_durations.values())
+    worst = {nodeid: max(d for d, _ in attempts) for nodeid, attempts in _test_durations.items()}
+    retried = {
+        nodeid: [
+            {"attempt": i, "duration": round(d, 3), "outcome": outcome}
+            for i, (d, outcome) in enumerate(attempts, start=1)
+        ]
+        for nodeid, attempts in sorted(_test_durations.items())
+        if len(attempts) > 1
+    }
+    durations = sorted(worst.values())
     if len(durations) >= 2:
         # method="inclusive" interpolates within the observed range, so
         # p95 can never exceed max_duration as the default method can
@@ -137,7 +182,9 @@ def _write_durations_file() -> None:
         "run_id": os.getenv("GITHUB_RUN_ID", "local"),
         "run_number": int(run_number) if run_number else None,
         "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
-        "durations": {nodeid: round(d, 3) for nodeid, d in sorted(_test_durations.items())},
+        "durations": {nodeid: round(d, 3) for nodeid, d in sorted(worst.items())},
+        "retried": retried,
+        "retried_count": len(retried),
         "max_duration": round(durations[-1], 3),
         "median_duration": round(statistics.median(durations), 3),
         "p95_duration": round(p95, 3),
@@ -244,6 +291,7 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "smoke: Quick smoke tests")
     config.addinivalue_line("markers", "ui: UI interaction tests")
     config.addinivalue_line("markers", "slow: Long-running tests")
+    config.addinivalue_line("markers", "no_rerun: Exempt from the smoke retry budget")
 
     # Create test results directory
     results_dir = os.getenv("TEST_RESULTS_DIR", "test-results")

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -91,6 +91,7 @@ def test_no_console_errors(page: Page) -> None:
 
 
 @pytest.mark.smoke
+@pytest.mark.no_rerun
 def test_first_navigation_response_time(first_navigation: FirstNavigation) -> None:
     """Test the session's first navigation against its latency budget.
 
@@ -98,6 +99,10 @@ def test_first_navigation_response_time(first_navigation: FirstNavigation) -> No
     ran, so this is the one navigation that paid connection setup (DNS,
     TCP, TLS) in this process. Every other timing in the suite reuses
     that state, which is what makes this the looser of the two budgets.
+
+    Exempt from the smoke retry budget: the measurement is taken once
+    per session, so a rerun would re-assert the identical cached value
+    and only burn the rerun delay.
 
     Args:
         first_navigation: Session-scoped first-navigation measurement

--- a/uv.lock
+++ b/uv.lock
@@ -549,6 +549,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/60/a90ca1cc6cffcb97b4260ed0ad2b7934b999d7c48abe4ea0840344862a3b/pytest_rerunfailures-16.4.tar.gz", hash = "sha256:8222d17c37eb7b9e4d6fc96a3c724ff4e1a5c97a5cc7cbb2c19e9282cfd21a11", size = 36635, upload-time = "2026-07-01T06:30:56.813Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/93/3cdcc4033444e822e01b573414b03fd37fd5533070c750477b8f5fa5224b/pytest_rerunfailures-16.4-py3-none-any.whl", hash = "sha256:f69b5beb39622c90d1e44bd945d826eff6db545dcf0b68f52b7e4ad15eaf6d6c", size = 16955, upload-time = "2026-07-01T06:30:55.333Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -630,6 +643,7 @@ dependencies = [
     { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-playwright" },
+    { name = "pytest-rerunfailures" },
     { name = "python-dotenv" },
 ]
 
@@ -646,6 +660,7 @@ requires-dist = [
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-playwright", specifier = ">=0.5.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 


### PR DESCRIPTION
## Summary
Implements #61, whose stated blockers (#57 tracing, #58 duration metrics) both landed. Adds `pytest-rerunfailures` with a retry budget scoped to smoke tests only, applied through `pytest_collection_modifyitems` rather than a global `--reruns` flag so retries cannot silently extend to the UI suite - there a rerun would mask a real regression rather than absorb a transient network stall.

## The blocker was not actually cleared by #57 and #58 landing
This issue was blocked because "retries suppress exactly the signal those issues capture." Having #58 merged turns out not to be sufficient, and I verified this rather than assuming it.

Against a deliberately flaky test (2.3s stalling attempt, then a fast passing retry), `durations.json` recorded **0.328s**. The metrics hook keyed by node id and assigned, so the retry's fast attempt overwrote the stall. Adding retries on top of #58 as-written would have erased precisely the evidence #58 exists to capture - the exact failure mode the issue warned about.

So the hook now appends per attempt instead of overwriting:
- **`durations`** reports the **slowest** attempt, not the last, so a papered-over stall still reaches `max_duration`, `p95_duration`, and `slow_count`
- **`retried`** (new) preserves every attempt of a retried test with its duration and outcome
- **`retried_count`** (new) gives the run-level count

The same scenario now records `2.311s`, with both attempts listed (`rerun` then `passed`).

## Exemption
`test_first_navigation_response_time` carries a new `no_rerun` marker. Its verdict comes from a session-scoped measurement, so a rerun re-reads the identical cached value, fails identically, and only burns the delay. Measured: it fails in 0.49s instead of spending 10s on two futile retries.

## Verification
| Acceptance criterion | Evidence |
|---|---|
| Retries apply only to smoke tests | Non-smoke UI probe: `1 failed` in 0.78s, **no reruns**. Smoke probe, same bad URL: `1 failed, 2 rerun` in 11.09s |
| Stalled-then-passing test stays visible | `durations.json` shows `2.311s` (worst attempt) plus full `retried` detail; was `0.328s` before the fix |
| Rerun attempts still contribute traces | Retained `trace.zip` decoded and its event span measured at **2.4s** - the stalled attempt, not the 0.33s rerun. No change needed |
| `no_rerun` exemption works | First-navigation test fails once in 0.49s with no rerun |

Full suite 19 passed; `-m smoke` 8 passed; `ruff`, `ruff format --check`, `mypy` clean. `pytest-rerunfailures` went into main `dependencies` (not dev) since it changes scheduled monitoring behavior, and the Dockerfile's `uv sync --locked` picks it up.

## Trade-off worth naming
Retries buy noise reduction by discarding evidence. That is why they are scoped to smoke only, capped at 2, and paired with attempt-level preservation - a green run that required retries is now distinguishable from one that did not, via `retried_count`. Without that, #59's incident gating would go quiet on a site that is degrading rather than down.

Closes #61
