### PR TITLE
fix: derive the HTTPS-redirect target from base_url instead of hardcoding it

### DIFF
--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -176,6 +176,7 @@ def test_https_redirect(page: Page, base_url: str) -> None:
         page: Playwright page fixture
         base_url: Base URL of the site under test
     """
+    expected_host = urlsplit(base_url).hostname
     if urlsplit(base_url).scheme != "https":
         pytest.skip(f"Base URL is not HTTPS, no redirect to verify: {base_url}")
     if is_local(base_url):
@@ -188,8 +189,14 @@ def test_https_redirect(page: Page, base_url: str) -> None:
 
     assert response is not None, "No response received"
 
-    # Check that we ended up on HTTPS
-    final_url = page.url
-    assert final_url.startswith("https://"), f"Expected HTTPS, got: {final_url}"
+    # Check that we ended up on HTTPS, still on the configured target.
+    # The host matters as much as the scheme: a redirect that lands
+    # somewhere else (production, a parked domain) would otherwise pass
+    # while reporting on a site this run was not asked to test.
+    final = urlsplit(page.url)
+    assert final.scheme == "https", f"Expected HTTPS, got: {page.url}"
+    assert final.hostname == expected_host, (
+        f"Redirect left the configured target: expected host {expected_host}, got {page.url}"
+    )
 
-    logger.info("Successfully redirected to: %s", final_url)
+    logger.info("Successfully redirected to: %s", page.url)

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -13,7 +13,7 @@ from playwright.sync_api import Page, expect
 
 from tests.utils.logger import get_logger
 from tests.utils.timing import PAGE_LOAD_TIMEOUT_MS, FirstNavigation
-from tests.utils.urls import http_variant, is_local
+from tests.utils.urls import http_variant, is_local, same_site
 
 logger = get_logger(__name__)
 
@@ -176,7 +176,6 @@ def test_https_redirect(page: Page, base_url: str) -> None:
         page: Playwright page fixture
         base_url: Base URL of the site under test
     """
-    expected_host = urlsplit(base_url).hostname
     if urlsplit(base_url).scheme != "https":
         pytest.skip(f"Base URL is not HTTPS, no redirect to verify: {base_url}")
     if is_local(base_url):
@@ -192,11 +191,11 @@ def test_https_redirect(page: Page, base_url: str) -> None:
     # Check that we ended up on HTTPS, still on the configured target.
     # The host matters as much as the scheme: a redirect that lands
     # somewhere else (production, a parked domain) would otherwise pass
-    # while reporting on a site this run was not asked to test.
-    final = urlsplit(page.url)
-    assert final.scheme == "https", f"Expected HTTPS, got: {page.url}"
-    assert final.hostname == expected_host, (
-        f"Redirect left the configured target: expected host {expected_host}, got {page.url}"
+    # while reporting on a site this run was not asked to test. An
+    # apex/www hop is not that, so same_site allows it.
+    assert urlsplit(page.url).scheme == "https", f"Expected HTTPS, got: {page.url}"
+    assert same_site(page.url, base_url), (
+        f"Redirect left the configured target {base_url}, landed on {page.url}"
     )
 
     logger.info("Successfully redirected to: %s", page.url)

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -6,12 +6,14 @@ These tests should run quickly and catch major breakages.
 
 import time
 from typing import Any
+from urllib.parse import urlsplit
 
 import pytest
 from playwright.sync_api import Page, expect
 
 from tests.utils.logger import get_logger
 from tests.utils.timing import PAGE_LOAD_TIMEOUT_MS, FirstNavigation
+from tests.utils.urls import http_variant, is_local
 
 logger = get_logger(__name__)
 
@@ -161,15 +163,28 @@ def test_main_content_visible(page: Page) -> None:
 
 
 @pytest.mark.smoke
-def test_https_redirect(page: Page) -> None:
-    """Test that HTTP requests redirect to HTTPS.
+def test_https_redirect(page: Page, base_url: str) -> None:
+    """Test that HTTP requests to the target redirect to HTTPS.
+
+    The URL is derived from base_url rather than hardcoded so that a run
+    pointed elsewhere via BASE_URL never contacts production. Targets
+    that cannot answer the question are skipped rather than failed: a
+    plain-HTTP base has no redirect to assert, and a local dev server
+    typically terminates TLS without an HTTP listener to redirect from.
 
     Args:
         page: Playwright page fixture
+        base_url: Base URL of the site under test
     """
-    logger.info("Testing HTTPS redirect")
+    if urlsplit(base_url).scheme != "https":
+        pytest.skip(f"Base URL is not HTTPS, no redirect to verify: {base_url}")
+    if is_local(base_url):
+        pytest.skip(f"Local target does not serve an HTTP redirect: {base_url}")
 
-    response = page.goto("http://kyledarden.com")
+    http_url = http_variant(base_url)
+    logger.info("Testing HTTPS redirect from %s", http_url)
+
+    response = page.goto(http_url)
 
     assert response is not None, "No response received"
 

--- a/tests/smoke/test_urls.py
+++ b/tests/smoke/test_urls.py
@@ -6,6 +6,8 @@ issue #28, where test_https_redirect contacted production regardless of
 BASE_URL. Runs offline: no browser, no network.
 """
 
+from urllib.parse import urlsplit
+
 import pytest
 
 from tests.utils.urls import http_variant, is_local
@@ -38,15 +40,27 @@ def test_http_variant_preserves_target(configured_url: str, expected: str) -> No
 
 
 @pytest.mark.smoke
-def test_http_variant_never_reaches_production_for_other_targets() -> None:
+@pytest.mark.parametrize(
+    "configured_url",
+    [
+        "https://staging.example.com",
+        # A host that merely contains the production name must not be
+        # mistaken for it, which a substring check would get wrong
+        "https://staging.kyledarden.com",
+    ],
+)
+def test_http_variant_never_reaches_production_for_other_targets(configured_url: str) -> None:
     """Test that a non-production base URL yields no production target.
 
     This is the acceptance criterion of issue #28 stated directly: a run
-    pointed at staging must not contact kyledarden.com.
-    """
-    derived = http_variant("https://staging.example.com")
+    pointed elsewhere must not contact kyledarden.com itself.
 
-    assert PRODUCTION_HOST not in derived, f"Derived URL leaks production host: {derived}"
+    Args:
+        configured_url: Base URL a run could be pointed at
+    """
+    derived_host = urlsplit(http_variant(configured_url)).hostname
+
+    assert derived_host != PRODUCTION_HOST, f"Derived URL leaks production host: {derived_host}"
 
 
 @pytest.mark.smoke

--- a/tests/smoke/test_urls.py
+++ b/tests/smoke/test_urls.py
@@ -10,7 +10,7 @@ from urllib.parse import urlsplit
 
 import pytest
 
-from tests.utils.urls import http_variant, is_local
+from tests.utils.urls import http_variant, is_local, same_site
 
 # The production default. A derived URL may only name this host when the
 # base URL did, which is what makes BASE_URL redirection trustworthy.
@@ -61,6 +61,38 @@ def test_http_variant_never_reaches_production_for_other_targets(configured_url:
     derived_host = urlsplit(http_variant(configured_url)).hostname
 
     assert derived_host != PRODUCTION_HOST, f"Derived URL leaks production host: {derived_host}"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("landed_on", "configured_url", "expected"),
+    [
+        ("https://kyledarden.com/", "https://kyledarden.com", True),
+        # kyledarden.com canonicalizes www to the apex, so a run pointed
+        # at the www host lands here and must not be called a failure
+        ("https://kyledarden.com/", "https://www.kyledarden.com", True),
+        # Other sites canonicalize the other way
+        ("https://www.example.com/", "https://example.com", True),
+        # An unrelated host is still a different site
+        ("https://kyledarden.com/", "https://staging.example.com", False),
+        ("https://kyledarden.com/", "https://staging.kyledarden.com", False),
+    ],
+)
+def test_same_site_allows_www_hops_only(
+    landed_on: str, configured_url: str, expected: bool
+) -> None:
+    """Test that apex/www counts as one site and unrelated hosts do not.
+
+    This is what keeps the redirect assertion honest: strict enough that
+    landing on production is caught, loose enough that a legitimate
+    canonicalizing hop is not reported as a failure.
+
+    Args:
+        landed_on: URL the redirect finished on
+        configured_url: Base URL a run could be pointed at
+        expected: Whether the two address the same site
+    """
+    assert same_site(landed_on, configured_url) is expected
 
 
 @pytest.mark.smoke

--- a/tests/smoke/test_urls.py
+++ b/tests/smoke/test_urls.py
@@ -1,0 +1,72 @@
+"""Target-derivation tests.
+
+Verifies that the URLs tests contact are derived from the configured
+base URL rather than hardcoded. Guards against a reintroduction of
+issue #28, where test_https_redirect contacted production regardless of
+BASE_URL. Runs offline: no browser, no network.
+"""
+
+import pytest
+
+from tests.utils.urls import http_variant, is_local
+
+# The production default. A derived URL may only name this host when the
+# base URL did, which is what makes BASE_URL redirection trustworthy.
+PRODUCTION_HOST = "kyledarden.com"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("configured_url", "expected"),
+    [
+        ("https://kyledarden.com", "http://kyledarden.com/"),
+        ("https://staging.example.com", "http://staging.example.com/"),
+        ("https://staging.example.com/", "http://staging.example.com/"),
+        ("https://staging.example.com/app", "http://staging.example.com/app"),
+        ("https://staging.example.com:8443", "http://staging.example.com:8443/"),
+        ("https://staging.example.com?debug=1", "http://staging.example.com/"),
+    ],
+)
+def test_http_variant_preserves_target(configured_url: str, expected: str) -> None:
+    """Test that only the scheme changes when deriving the HTTP URL.
+
+    Args:
+        configured_url: Base URL a run could be pointed at
+        expected: The HTTP URL that addresses the same target
+    """
+    assert http_variant(configured_url) == expected
+
+
+@pytest.mark.smoke
+def test_http_variant_never_reaches_production_for_other_targets() -> None:
+    """Test that a non-production base URL yields no production target.
+
+    This is the acceptance criterion of issue #28 stated directly: a run
+    pointed at staging must not contact kyledarden.com.
+    """
+    derived = http_variant("https://staging.example.com")
+
+    assert PRODUCTION_HOST not in derived, f"Derived URL leaks production host: {derived}"
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("configured_url", "expected"),
+    [
+        ("https://localhost:3000", True),
+        ("http://127.0.0.1:8000", True),
+        ("https://kyledarden.com", False),
+        ("https://localhost.example.com", False),
+    ],
+)
+def test_is_local_identifies_loopback_targets(configured_url: str, expected: bool) -> None:
+    """Test that loopback targets are recognized and others are not.
+
+    The suffixed hostname case matters: a substring check would skip the
+    redirect test against a real remote host named localhost.example.com.
+
+    Args:
+        configured_url: Base URL a run could be pointed at
+        expected: Whether the host resolves to the local machine
+    """
+    assert is_local(configured_url) is expected

--- a/tests/utils/urls.py
+++ b/tests/utils/urls.py
@@ -29,6 +29,41 @@ def http_variant(base_url: str) -> str:
     return urlunsplit(("http", parsed.netloc, parsed.path or "/", "", ""))
 
 
+def same_site(url: str, other: str) -> bool:
+    """Report whether two URLs address the same site.
+
+    A leading "www." is ignored on either side, because canonicalizing
+    between the apex and the www host is a normal redirect and not the
+    kind of host change worth failing over. kyledarden.com canonicalizes
+    www to the apex; other targets go the other way, and a check that
+    fixed a direction would produce false failures on one of them.
+
+    Comparison is otherwise exact, so an unrelated host (production, a
+    parked domain) is still reported as a different site.
+
+    Args:
+        url: First URL to compare
+        other: Second URL to compare
+
+    Returns:
+        True when both address the same site
+    """
+    return _site_host(url) == _site_host(other)
+
+
+def _site_host(url: str) -> str | None:
+    """Return the hostname of url with any leading "www." removed.
+
+    Args:
+        url: URL to take the hostname from
+
+    Returns:
+        The bare hostname, or None when the URL carries no host
+    """
+    host = urlsplit(url).hostname
+    return host.removeprefix("www.") if host else host
+
+
 def is_local(base_url: str) -> bool:
     """Report whether base_url points at the local machine.
 

--- a/tests/utils/urls.py
+++ b/tests/utils/urls.py
@@ -1,0 +1,41 @@
+"""URL helpers for deriving test targets from the configured base URL.
+
+Every target a test contacts must come from base_url. Hardcoding a host
+in a test (issue #28) means a run pointed at staging still hits
+production, which makes that test wrong in any non-production run.
+"""
+
+from urllib.parse import urlsplit, urlunsplit
+
+# Hostnames that resolve to the developer's own machine, where an HTTPS
+# base URL is served directly rather than fronted by a redirecting edge.
+LOCAL_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def http_variant(base_url: str) -> str:
+    """Return base_url with its scheme swapped to plain HTTP.
+
+    Host, port, and path are preserved so the result addresses the same
+    target; query and fragment are dropped because a redirect probe has
+    no use for them.
+
+    Args:
+        base_url: Base URL of the site under test
+
+    Returns:
+        The same target addressed over http
+    """
+    parsed = urlsplit(base_url)
+    return urlunsplit(("http", parsed.netloc, parsed.path or "/", "", ""))
+
+
+def is_local(base_url: str) -> bool:
+    """Report whether base_url points at the local machine.
+
+    Args:
+        base_url: Base URL of the site under test
+
+    Returns:
+        True when the host is a loopback name or address
+    """
+    return urlsplit(base_url).hostname in LOCAL_HOSTNAMES


### PR DESCRIPTION
Closes #28.

## Problem

`test_https_redirect` navigated to `http://kyledarden.com` literally. A run pointed at staging or a local target via `BASE_URL` still contacted production for this one test, which breaks the suite's configurability promise and makes the test's verdict meaningless off production - it reported on a site the run was not testing.

## Change

- The probe URL is derived from `base_url` by swapping the scheme, preserving host, port, and path.
- Targets that cannot answer the question are skipped with a stated reason rather than failed: a plain-HTTP base has no redirect to assert, and a loopback target is typically served directly with no HTTP listener to redirect from.
- The derivation lives in `tests/utils/urls.py` so it can be exercised offline, and `tests/smoke/test_urls.py` pins it - including the acceptance criterion stated directly (a staging base URL must yield no production host).

`is_local` compares hostnames rather than doing a substring match, so a real remote host named `localhost.example.com` is still tested rather than silently skipped.

## Verification

| Target | Result |
| --- | --- |
| default (production) | passed, redirect verified |
| `BASE_URL=https://staging.example.com` | contacted `http://staging.example.com/` only, failed on DNS - never touched kyledarden.com |
| `BASE_URL=http://localhost:3000` | skipped: "Base URL is not HTTPS, no redirect to verify" |
| `BASE_URL=https://localhost:3000` | skipped: "Local target does not serve an HTTP redirect" |

Full smoke suite: 19 passed. Ruff and mypy clean.

## Note for future test authors

Naming a `parametrize` argument `base_url` collides with the session-scoped fixture and raises `ScopeMismatch` on every case. The params here are named `configured_url` for that reason.