### PR TITLE
fix: wire BROWSER and SCREENSHOTS_DIR, remove the phantom TIMEOUT var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,8 @@ BASE_URL=https://kyledarden.com
 # Test configuration
 HEADLESS=true
 SLOWMO=0
-TIMEOUT=30000
 
-# Browser configuration
+# Browser configuration (chromium, firefox, or webkit)
 BROWSER=chromium
 
 # Playwright options

--- a/README.md
+++ b/README.md
@@ -128,14 +128,21 @@ BASE_URL=https://kyledarden.com
 
 # Browser settings
 HEADLESS=true
-BROWSER=chromium
+SLOWMO=0
+BROWSER=chromium          # chromium, firefox, or webkit; --browser wins
 VIEWPORT_WIDTH=1280
 VIEWPORT_HEIGHT=720
 
-# Test settings
-TIMEOUT=30000
+# Output
+TEST_RESULTS_DIR=test-results
+SCREENSHOTS_DIR=test-results/screenshots
 LOG_LEVEL=INFO
 ```
+
+Navigation timeouts are deliberate constants in `tests/utils/timing.py`,
+not an environment setting: an unchosen timeout value had previously
+become the suite's de-facto performance gate, so the ceilings now live
+in code where they read as a decision (see issues #57-61).
 
 ## CI/CD
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ from dotenv import load_dotenv
 from playwright.sync_api import Browser, Page
 from playwright.sync_api import Error as PlaywrightError
 
+from tests.utils.config import resolve_browsers, screenshots_dir
 from tests.utils.logger import get_logger
 from tests.utils.timing import (
     FIRST_NAVIGATION_TIMEOUT_MS,
@@ -294,12 +295,18 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "slow: Long-running tests")
     config.addinivalue_line("markers", "no_rerun: Exempt from the smoke retry budget")
 
-    # Create test results directory
+    # Honor BROWSER when no --browser was passed. pytest_generate_tests
+    # reads config.option.browser (falling back to chromium), and this
+    # hook runs before it, so setting it here selects the browser env
+    # override with the same CLI-wins semantics as HEADLESS/SLOWMO.
+    browsers = resolve_browsers(config.getoption("browser") or [], os.environ)
+    if browsers is not None:
+        config.option.browser = browsers
+
+    # Create test results and screenshots directories
     results_dir = os.getenv("TEST_RESULTS_DIR", "test-results")
     os.makedirs(results_dir, exist_ok=True)
-
-    screenshots_dir = os.path.join(results_dir, "screenshots")
-    os.makedirs(screenshots_dir, exist_ok=True)
+    os.makedirs(screenshots_dir(os.environ), exist_ok=True)
 
     logger.info("Test results directory: %s", results_dir)
 
@@ -315,10 +322,8 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[None]) ->
         # Test failed, capture screenshot if page fixture was used
         page = getattr(item, "funcargs", {}).get("page")
         if page:
-            screenshot_dir = os.path.join(
-                os.getenv("TEST_RESULTS_DIR", "test-results"), "screenshots"
-            )
-            screenshot_path = os.path.join(screenshot_dir, f"{item.name}.png")
+            screenshot_dir = screenshots_dir(os.environ)
+            screenshot_path = str(screenshot_dir / f"{item.name}.png")
             try:
                 page.screenshot(path=screenshot_path)
                 logger.info("Screenshot saved: %s", screenshot_path)

--- a/tests/smoke/test_config_env.py
+++ b/tests/smoke/test_config_env.py
@@ -1,0 +1,97 @@
+"""Configuration-resolution tests.
+
+Pins the env-to-setting helpers that back the documented BROWSER and
+SCREENSHOTS_DIR variables, so a documented setting cannot silently
+regress to doing nothing (issue #29). The resolution runs offline; a
+separate live check confirms BROWSER actually selects the running
+browser.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.utils.config import resolve_browsers, screenshots_dir
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("cli_browsers", "env", "expected"),
+    [
+        # BROWSER fills in when no --browser was passed
+        ([], {"BROWSER": "firefox"}, ["firefox"]),
+        # A --browser CLI option wins; BROWSER is ignored
+        (["webkit"], {"BROWSER": "firefox"}, None),
+        # Nothing configured: leave the plugin default untouched
+        ([], {}, None),
+    ],
+)
+def test_resolve_browsers(
+    cli_browsers: list[str], env: dict[str, str], expected: list[str] | None
+) -> None:
+    """Test that BROWSER is honored only when no CLI browser was given.
+
+    Args:
+        cli_browsers: Browsers from the --browser option
+        env: Environment mapping under test
+        expected: The browser list to apply, or None to change nothing
+    """
+    assert resolve_browsers(cli_browsers, env) == expected
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        # SCREENSHOTS_DIR, when set, is used verbatim
+        ({"SCREENSHOTS_DIR": "/tmp/shots"}, Path("/tmp/shots")),
+        # otherwise it falls back under TEST_RESULTS_DIR
+        ({"TEST_RESULTS_DIR": "out"}, Path("out/screenshots")),
+        # and to the default results dir when neither is set
+        ({}, Path("test-results/screenshots")),
+        # SCREENSHOTS_DIR wins even when TEST_RESULTS_DIR is also set
+        (
+            {"SCREENSHOTS_DIR": "shots", "TEST_RESULTS_DIR": "out"},
+            Path("shots"),
+        ),
+    ],
+)
+def test_screenshots_dir(env: dict[str, str], expected: Path) -> None:
+    """Test that the screenshots directory honors its variables.
+
+    Args:
+        env: Environment mapping under test
+        expected: The directory failure screenshots should land in
+    """
+    assert screenshots_dir(env) == expected
+
+
+@pytest.mark.smoke
+def test_browser_env_selects_running_browser(
+    browser_name: str, pytestconfig: pytest.Config
+) -> None:
+    """Test that BROWSER selects the browser the session actually runs.
+
+    This closes the loop the offline test cannot: it proves the resolved
+    value reached pytest-playwright and drove browser selection, not just
+    that the helper computed it. Skipped unless BROWSER is the setting in
+    effect, which means it is set and no --browser CLI option overrode
+    it, matching resolve_browsers' precedence.
+
+    Args:
+        browser_name: The running browser, from pytest-playwright
+        pytestconfig: Session config, used to detect a --browser option
+    """
+    # config.option.browser cannot answer this: pytest_configure already
+    # overwrote it with the env value, erasing the CLI-vs-env distinction.
+    # The raw invocation args still carry what the user actually typed.
+    raw_args = pytestconfig.invocation_params.args
+    if any(arg == "--browser" or arg.startswith("--browser=") for arg in raw_args):
+        pytest.skip("--browser CLI option overrides BROWSER; env has no effect here")
+    if not os.getenv("BROWSER"):
+        pytest.skip("BROWSER not set; nothing to prove about its effect")
+
+    assert browser_name == os.environ["BROWSER"], (
+        f"BROWSER={os.environ['BROWSER']} did not select the running browser ({browser_name})"
+    )

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -1,0 +1,59 @@
+"""Environment-driven configuration helpers.
+
+Keeps the resolution of documented environment variables in pure
+functions so each variable's effect can be pinned offline, without a
+browser or a live pytest session. Issue #29: a documented setting that
+silently does nothing is worse than none, because users change it and
+see no effect.
+"""
+
+from collections.abc import Mapping
+from pathlib import Path
+
+# Where failure screenshots land when SCREENSHOTS_DIR is unset: a
+# subdirectory of the results dir, which is where the hook wrote
+# unconditionally before the variable was honored.
+DEFAULT_RESULTS_DIR = "test-results"
+SCREENSHOTS_SUBDIR = "screenshots"
+
+
+def resolve_browsers(cli_browsers: list[str], env: Mapping[str, str]) -> list[str] | None:
+    """Resolve which browsers to run from the CLI option and BROWSER env.
+
+    A --browser CLI option always wins: when the user passed one,
+    cli_browsers is non-empty and BROWSER is ignored, mirroring how
+    HEADLESS and SLOWMO defer to their CLI flags. BROWSER fills in only
+    when no CLI browser was given. Returning None means "change nothing",
+    so pytest-playwright keeps its own default of chromium.
+
+    Args:
+        cli_browsers: Browsers from the --browser option (may be empty)
+        env: Environment mapping to read BROWSER from
+
+    Returns:
+        The browser list to apply, or None to leave the plugin default
+    """
+    if cli_browsers:
+        return None
+    browser = env.get("BROWSER")
+    return [browser] if browser else None
+
+
+def screenshots_dir(env: Mapping[str, str]) -> Path:
+    """Resolve the directory that failure screenshots are written to.
+
+    Honors SCREENSHOTS_DIR when set; otherwise falls back to the
+    screenshots subdirectory of TEST_RESULTS_DIR, preserving the path
+    the hook used before SCREENSHOTS_DIR was wired in.
+
+    Args:
+        env: Environment mapping to read SCREENSHOTS_DIR/TEST_RESULTS_DIR from
+
+    Returns:
+        Directory path for failure screenshots
+    """
+    explicit = env.get("SCREENSHOTS_DIR")
+    if explicit:
+        return Path(explicit)
+    results = env.get("TEST_RESULTS_DIR", DEFAULT_RESULTS_DIR)
+    return Path(results) / SCREENSHOTS_SUBDIR


### PR DESCRIPTION
Closes #29.

## Problem

Three settings in `.env.example` and the README were documented but read by no code, so changing them did nothing:

- `TIMEOUT=30000` - never applied; Playwright's defaults were used.
- `BROWSER=chromium` - never read; the browser was whatever pytest-playwright defaulted to.
- `SCREENSHOTS_DIR` - defined but the screenshot hook hardcoded `TEST_RESULTS_DIR/screenshots`.

Documented config that silently no-ops is worse than none: users adjust it and trust an effect that never happens.

## Change

The env-to-setting logic lives in `tests/utils/config.py` as pure functions so each variable's effect is pinned offline (same shape as the URL helpers from #28).

| Var | Decision | Rationale |
| --- | --- | --- |
| `BROWSER` | **wired** | `resolve_browsers` folds it into pytest-playwright's selection with the CLI-wins precedence the suite already uses for `HEADLESS`/`SLOWMO`. `pytest_configure` sets `config.option.browser` before `pytest_generate_tests` reads it, so `--browser` still wins. |
| `SCREENSHOTS_DIR` | **wired** | `screenshots_dir` backs both the failure-screenshot hook and the directory it creates; falls back to the previous `TEST_RESULTS_DIR/screenshots` path when unset. |
| `TIMEOUT` | **removed** | Its documented value `30000` is exactly the implicit Playwright default that #57-61 deliberately replaced with explicit code budgets after it became the suite's unchosen performance gate. Re-exposing it would reintroduce that bug; the README now points at the constants in `tests/utils/timing.py`. |

## Tests & verification

`tests/smoke/test_config_env.py` pins `resolve_browsers` and `screenshots_dir` offline. A live test asserts `BROWSER` selects the running browser, skipping when a `--browser` CLI option overrode it - detected via the raw invocation args, because `pytest_configure` has by then overwritten `config.option.browser` and erased the CLI-vs-env distinction.

Verified end to end (firefox is installed alongside chromium):

- `BROWSER=firefox` → session runs firefox; live test passes.
- `BROWSER=firefox --browser chromium` → chromium runs (CLI wins); live test skips instead of false-failing.
- `SCREENSHOTS_DIR=/tmp/shots` + a forced failure → a real 90KB PNG landed in the configured directory.

Full smoke suite: 32 passed, 1 skipped (the `BROWSER` live test, when unset). Ruff, format, mypy clean.

I also confirmed the remaining `.env.example` variables (`LOG_LEVEL`, `HEADLESS`, `SLOWMO`, `VIEWPORT_*`, `TEST_RESULTS_DIR`) are actually read, so no phantom is left behind.