### PR TITLE
test: eliminate flakiness sources, measure performance via Navigation Timing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ configuration management, and test utilities.
 import json
 import os
 import statistics
-import time
 from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -24,6 +23,8 @@ from tests.utils.timing import (
     FIRST_NAVIGATION_TIMEOUT_MS,
     PAGE_LOAD_TIMEOUT_MS,
     FirstNavigation,
+    NavigationTiming,
+    read_navigation_timing,
 )
 
 # Create test-results directory immediately when conftest is imported
@@ -95,21 +96,21 @@ def first_navigation(browser: Browser, base_url: str) -> FirstNavigation:
         base_url: Base URL of the site under test
 
     Returns:
-        Elapsed seconds and any navigation error
+        The browser-measured navigation timing and any navigation error
     """
     context = browser.new_context(base_url=base_url)
     error: str | None = None
-    start = time.perf_counter()
+    timing: NavigationTiming | None = None
     try:
         page = context.new_page()
         page.goto("/", wait_until="load", timeout=FIRST_NAVIGATION_TIMEOUT_MS)
+        timing = read_navigation_timing(page)
     except PlaywrightError as exc:
         error = str(exc)
     finally:
-        seconds = time.perf_counter() - start
         context.close()
-    logger.info("First navigation took %.2fs (error: %s)", seconds, error)
-    return FirstNavigation(seconds=seconds, error=error)
+    logger.info("First navigation timing: %s (error: %s)", timing, error)
+    return FirstNavigation(timing=timing, error=error)
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -22,9 +22,10 @@ logger = get_logger(__name__)
 # busy runner no longer produces false alarms unrelated to the site.
 
 # First-navigation budget, deliberately the looser of the two. This
-# navigation pays connection setup (DNS, TCP, TLS), visible as non-zero
-# connect timing; cold domContentLoaded is ~280ms against the live site,
-# so 3000ms is failure territory with wide headroom for a cold CI path.
+# navigation pays one-time connection setup - DNS resolution, then the
+# TCP and TLS handshake - that later warm navigations reuse; cold
+# domContentLoaded is ~280ms against the live site, so 3000ms is failure
+# territory with wide headroom for a cold CI path.
 FIRST_NAVIGATION_DCL_BUDGET_MS = 3000.0
 
 # Warm-navigation budget, deliberately tighter: connection state is

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -4,7 +4,6 @@ Fast, critical tests that verify core functionality and site availability.
 These tests should run quickly and catch major breakages.
 """
 
-import time
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -12,18 +11,27 @@ import pytest
 from playwright.sync_api import Page, expect
 
 from tests.utils.logger import get_logger
-from tests.utils.timing import PAGE_LOAD_TIMEOUT_MS, FirstNavigation
+from tests.utils.timing import PAGE_LOAD_TIMEOUT_MS, FirstNavigation, read_navigation_timing
 from tests.utils.urls import http_variant, is_local, same_site
 
 logger = get_logger(__name__)
 
-# Latency budget for the session's first navigation, which pays DNS,
-# TCP, and TLS setup on top of the request itself. Not a cache-cold
-# budget: the CDN edge cache is warm regardless of what the suite does.
-FIRST_NAVIGATION_BUDGET_SECONDS = 10.0
+# Budgets are set on domContentLoaded read from the browser's Navigation
+# Timing, not a Python wall clock: the metric is the site's own latency,
+# with CDP round-trip and CI runner scheduling jitter excluded, so a
+# busy runner no longer produces false alarms unrelated to the site.
 
-# Latency budget once connection state is established by earlier tests.
-WARM_LOAD_BUDGET_SECONDS = 5.0
+# First-navigation budget, deliberately the looser of the two. This
+# navigation pays connection setup (DNS, TCP, TLS), visible as non-zero
+# connect timing; cold domContentLoaded is ~280ms against the live site,
+# so 3000ms is failure territory with wide headroom for a cold CI path.
+FIRST_NAVIGATION_DCL_BUDGET_MS = 3000.0
+
+# Warm-navigation budget, deliberately tighter: connection state is
+# already established, so this catches steady latency regressions rather
+# than one-time setup. Warm domContentLoaded is ~95ms live; 1500ms stays
+# failure territory while absorbing CI network variance.
+WARM_DCL_BUDGET_MS = 1500.0
 
 
 @pytest.mark.smoke
@@ -82,11 +90,13 @@ def test_no_console_errors(page: Page) -> None:
             console_errors.append(msg.text)
             logger.warning("Console error: %s", msg.text)
 
+    # Attach the listener before navigating, then bound the collection
+    # window to the load event rather than a fixed sleep: errors from
+    # HTML parse, synchronous scripts, and load handlers are all captured
+    # by the time goto returns, and the extra second the sleep cost every
+    # run is gone.
     page.on("console", handle_console)
-    page.goto("/")
-
-    # Wait a moment for any delayed console errors
-    page.wait_for_timeout(1000)
+    page.goto("/", wait_until="load")
 
     assert len(console_errors) == 0, f"Found {len(console_errors)} console errors: {console_errors}"
     logger.info("No console errors found")
@@ -109,14 +119,19 @@ def test_first_navigation_response_time(first_navigation: FirstNavigation) -> No
     Args:
         first_navigation: Session-scoped first-navigation measurement
     """
-    logger.info("First navigation took %.2fs", first_navigation.seconds)
-
-    assert first_navigation.error is None, (
-        f"First navigation failed after {first_navigation.seconds:.2f}s: {first_navigation.error}"
+    assert first_navigation.error is None, f"First navigation failed: {first_navigation.error}"
+    timing = first_navigation.timing
+    assert timing is not None, "First navigation produced no timing"
+    logger.info(
+        "First navigation: dcl=%.0fms connect=%.0fms ttfb=%.0fms",
+        timing.dom_content_loaded_ms,
+        timing.connect_ms,
+        timing.ttfb_ms,
     )
-    assert first_navigation.seconds < FIRST_NAVIGATION_BUDGET_SECONDS, (
-        f"First navigation took {first_navigation.seconds:.2f}s "
-        f"(budget {FIRST_NAVIGATION_BUDGET_SECONDS:.0f}s)"
+
+    assert timing.dom_content_loaded_ms < FIRST_NAVIGATION_DCL_BUDGET_MS, (
+        f"First navigation domContentLoaded {timing.dom_content_loaded_ms:.0f}ms "
+        f"(budget {FIRST_NAVIGATION_DCL_BUDGET_MS:.0f}ms)"
     )
 
 
@@ -131,18 +146,21 @@ def test_warm_response_time(page: Page) -> None:
     Args:
         page: Playwright page fixture
     """
-    logger.info("Testing warm page load time")
+    logger.info("Testing warm navigation timing")
 
-    start_time = time.perf_counter()
     response = page.goto("/", wait_until="load")
-    load_time = time.perf_counter() - start_time
-
     assert response is not None, "No response received"
-    assert load_time < WARM_LOAD_BUDGET_SECONDS, (
-        f"Warm navigation took {load_time:.2f}s (budget {WARM_LOAD_BUDGET_SECONDS:.0f}s)"
+
+    timing = read_navigation_timing(page)
+    assert timing is not None, "Warm navigation produced no timing"
+    logger.info(
+        "Warm navigation: dcl=%.0fms ttfb=%.0fms", timing.dom_content_loaded_ms, timing.ttfb_ms
     )
 
-    logger.info("Page loaded in %.2fs", load_time)
+    assert timing.dom_content_loaded_ms < WARM_DCL_BUDGET_MS, (
+        f"Warm navigation domContentLoaded {timing.dom_content_loaded_ms:.0f}ms "
+        f"(budget {WARM_DCL_BUDGET_MS:.0f}ms)"
+    )
 
 
 @pytest.mark.smoke

--- a/tests/ui/test_ui_nav.py
+++ b/tests/ui/test_ui_nav.py
@@ -173,26 +173,24 @@ def test_images_load(page: Page) -> None:
     """
     logger.info("Testing image loading")
 
-    page.goto("/")
+    page.goto("/", wait_until="load")
 
-    # Wait for images to load
-    page.wait_for_load_state("networkidle")
+    # The load event waits for the initial HTML's eager images, so any
+    # image the browser reports as complete has finished fetching; a
+    # complete image with zero natural width is a broken resource. This
+    # checks load success directly instead of waiting on the network to idle,
+    # which the Playwright docs discourage and which hangs on pages with
+    # analytics beacons, and it does not fail on lazy images below the
+    # fold, which are simply not complete yet.
+    broken_images = page.evaluate(
+        """() => Array.from(document.images)
+            .filter(img => img.complete && img.naturalWidth === 0)
+            .map(img => img.currentSrc || img.src || '(no src)')"""
+    )
+    assert not broken_images, f"Broken images failed to load: {broken_images}"
 
     images = page.locator("img").all()
-    image_count = len(images)
-
-    if image_count > 0:
-        logger.info("Found %d images", image_count)
-
-        # Check that images have src attributes
-        for img in images[:5]:  # Test first 5 images
-            src = img.get_attribute("src")
-            assert src, "Image missing src attribute"
-            assert len(src) > 0, "Image has empty src attribute"
-
-        logger.info("Image sources are valid")
-    else:
-        logger.info("No images found on page")
+    logger.info("Found %d images, none broken", len(images))
 
 
 @pytest.mark.ui
@@ -251,29 +249,27 @@ def test_page_scroll(page: Page) -> None:
     """
     logger.info("Testing page scroll functionality")
 
-    page.goto("/")
+    page.goto("/", wait_until="load")
 
-    # Get initial scroll position
-    initial_scroll = page.evaluate("window.pageYOffset")
-
-    # Scroll down
-    page.evaluate("window.scrollTo(0, document.body.scrollHeight / 2)")
-
-    # Wait a moment for scroll to complete
-    page.wait_for_timeout(500)
-
-    # Get new scroll position
-    new_scroll = page.evaluate("window.pageYOffset")
-
-    # If page is long enough, scroll position should have changed
+    # Nothing to assert on a page that cannot scroll; skip rather than
+    # pass vacuously, and skip before scrolling so the wait below always
+    # has a real change to wait for.
     page_height = page.evaluate("document.body.scrollHeight")
     viewport_height = page.evaluate("window.innerHeight")
+    if page_height <= viewport_height:
+        pytest.skip("Page is too short to scroll")
 
-    if page_height > viewport_height:
-        assert new_scroll > initial_scroll, "Page did not scroll"
-        logger.info("Page scrolled from %d to %d", initial_scroll, new_scroll)
-    else:
-        logger.info("Page is too short to scroll")
+    initial_scroll = page.evaluate("window.pageYOffset")
+    page.evaluate("window.scrollTo(0, document.body.scrollHeight / 2)")
+
+    # Wait for the scroll to actually take effect instead of sleeping a
+    # fixed interval: this waits on the condition itself, so it tolerates
+    # smooth-scroll behavior without the flakiness of a guessed duration.
+    page.wait_for_function("start => window.pageYOffset > start", arg=initial_scroll)
+
+    new_scroll = page.evaluate("window.pageYOffset")
+    assert new_scroll > initial_scroll, "Page did not scroll"
+    logger.info("Page scrolled from %d to %d", initial_scroll, new_scroll)
 
 
 @pytest.mark.ui
@@ -293,9 +289,12 @@ def test_no_broken_styles(page: Page) -> None:
                 failed_resources.append(response.url)
                 logger.warning("Failed to load stylesheet: %s", response.url)
 
+    # The listener is attached before navigating, and stylesheets are
+    # render-blocking, so every stylesheet response has arrived by the
+    # load event. Waiting for load (goto's default) rather than
+    # that lets us capture them all without hanging on late beacons.
     page.on("response", handle_response)
-    page.goto("/")
-    page.wait_for_load_state("networkidle")
+    page.goto("/", wait_until="load")
 
     assert len(failed_resources) == 0, (
         f"Failed to load {len(failed_resources)} stylesheets: {failed_resources}"

--- a/tests/ui/test_ui_nav.py
+++ b/tests/ui/test_ui_nav.py
@@ -291,8 +291,8 @@ def test_no_broken_styles(page: Page) -> None:
 
     # The listener is attached before navigating, and stylesheets are
     # render-blocking, so every stylesheet response has arrived by the
-    # load event. Waiting for load (goto's default) rather than
-    # that lets us capture them all without hanging on late beacons.
+    # load event. Waiting for the load event rather than for the network
+    # to fall idle captures them all without hanging on late beacons.
     page.on("response", handle_response)
     page.goto("/", wait_until="load")
 

--- a/tests/utils/timing.py
+++ b/tests/utils/timing.py
@@ -47,7 +47,8 @@ class NavigationTiming(NamedTuple):
         ttfb_ms: Time to first byte (responseStart); server plus network
         dom_content_loaded_ms: domContentLoadedEventEnd; DOM ready
         load_ms: loadEventEnd; all subresources of the initial HTML done
-        connect_ms: connectEnd; DNS, TCP, and TLS setup complete
+        connect_ms: connectEnd; the TCP and TLS connection is established
+            (DNS resolution is the separate domainLookup phase)
     """
 
     ttfb_ms: float

--- a/tests/utils/timing.py
+++ b/tests/utils/timing.py
@@ -6,6 +6,8 @@ conftest module, which pytest may load under more than one module name.
 
 from typing import NamedTuple
 
+from playwright.sync_api import Page
+
 # Deliberate ceiling on every navigation in the suite, applied by the
 # page fixture in conftest.py. Replaces Playwright's implicit 30s
 # default, which previously acted as an unchosen performance gate:
@@ -18,14 +20,66 @@ PAGE_LOAD_TIMEOUT_MS = 15_000
 # a measured number instead of a bare timeout.
 FIRST_NAVIGATION_TIMEOUT_MS = 20_000
 
+# Reads the Navigation Timing Level 2 entry for the current document.
+# Every field is a DOMHighResTimeStamp in milliseconds measured by the
+# browser from navigation start, so the numbers are the site's own
+# latency: Python/CDP round-trip and CI runner scheduling jitter, which
+# make a wall-clock measurement flaky, are excluded by construction.
+_NAVIGATION_TIMING_JS = """() => {
+  const nav = performance.getEntriesByType('navigation')[0];
+  if (!nav) { return null; }
+  return {
+    ttfb_ms: nav.responseStart,
+    dom_content_loaded_ms: nav.domContentLoadedEventEnd,
+    load_ms: nav.loadEventEnd,
+    connect_ms: nav.connectEnd,
+  };
+}"""
+
+
+class NavigationTiming(NamedTuple):
+    """Browser-measured timing for a single navigation.
+
+    All values are milliseconds from navigation start, so they capture
+    what the site did, not what the harness added on top.
+
+    Attributes:
+        ttfb_ms: Time to first byte (responseStart); server plus network
+        dom_content_loaded_ms: domContentLoadedEventEnd; DOM ready
+        load_ms: loadEventEnd; all subresources of the initial HTML done
+        connect_ms: connectEnd; DNS, TCP, and TLS setup complete
+    """
+
+    ttfb_ms: float
+    dom_content_loaded_ms: float
+    load_ms: float
+    connect_ms: float
+
+
+def read_navigation_timing(page: Page) -> NavigationTiming | None:
+    """Read the current page's Navigation Timing metrics.
+
+    Should be called after the navigation has reached the load state, so
+    the load and domContentLoaded marks are populated rather than zero.
+
+    Args:
+        page: Playwright page whose navigation to measure
+
+    Returns:
+        The browser's timing for the navigation, or None when no
+        navigation entry exists (e.g. the navigation never completed)
+    """
+    raw = page.evaluate(_NAVIGATION_TIMING_JS)
+    return NavigationTiming(**raw) if raw is not None else None
+
 
 class FirstNavigation(NamedTuple):
     """Outcome of the first navigation performed in a test session.
 
     Attributes:
-        seconds: Wall-clock time spent in the navigation
+        timing: Browser-measured navigation timing, or None on failure
         error: Playwright error message, or None when it completed
     """
 
-    seconds: float
+    timing: NavigationTiming | None
     error: str | None


### PR DESCRIPTION
Closes #30. Foundation for #33 (the metric this introduces is what #33 will persist).

## Context

The issue is 10 days old and predates a lot of merged timing work, so I reconciled it against the code first. One of its four scope items was already done:

| Scope item | State |
| --- | --- |
| Fixed sleeps (`wait_for_timeout`) | **Done here** - 2 removed |
| `networkidle` | **Done here** - 2 removed |
| Wall-clock perf assertion → Navigation Timing | **Done here** |
| Scheduled-only reruns | **Already shipped in #66** - smoke-scoped `flaky` marker |

## Changes

**Fixed sleeps → event-based waits**
- `test_no_console_errors`: bounded its collection window with a blind `wait_for_timeout(1000)` (late errors slipped through, every run paid a second). Now tied to the load event.
- `test_page_scroll`: slept 500ms after scrolling. Now waits on the scroll condition itself (tolerates smooth-scroll) and `pytest.skip`s when the page is too short instead of passing vacuously.

**`networkidle` → `load` + targeted expectations**
- `test_no_broken_styles`: stylesheets are render-blocking, so their responses are already captured by `load`.
- `test_images_load`: verifies load success directly - a `complete` image with zero `naturalWidth` is broken - which also stops failing on lazy images below the fold.

**Wall-clock → Navigation Timing API**

`perf_counter` around `page.goto` timed Python/CDP round-trip and runner scheduling jitter *along with* the site, so a busy runner produced alarms unrelated to the site. Timing now comes from the browser's own Navigation Timing (`read_navigation_timing` in `tests/utils/timing.py`); the first-navigation and warm tests assert on `domContentLoaded`, a site-controlled metric. The two budgets keep the deliberate first-looser-than-warm ordering from #65.

## Grounding the budgets

I measured the live site (cold context, then warm) before setting thresholds:

| Navigation | connect | TTFB | DCL |
| --- | --- | --- | --- |
| cold | 84ms | 165ms | 279ms |
| warm | ~32ms | ~45ms | ~95ms |

Budgets: **first DCL 3000ms**, **warm DCL 1500ms** - clearly failure-territory with wide headroom for CI network variance, and the connection-setup phases (`connect`) confirm the first/warm split is real.

## Verification

- No `wait_for_timeout` / `networkidle` remains (code or comments).
- Live run: first nav `dcl=108ms connect=34ms ttfb=49ms`, warm `dcl=96ms`, scroll moved `0 → 869` via the event-based wait.
- Full suite: 43 passed, 1 skipped (the `BROWSER` env test). Ruff, format, mypy clean.