### PR TITLE
feat: persist per-run metrics and publish uptime/performance trend dashboard (#33)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
-# Keep the build context minimal: only pyproject.toml, uv.lock, and
-# tests/ are copied into the image.
+# Keep the build context minimal: only pyproject.toml, uv.lock, and the
+# app code (pipeline/, tests/) are copied into the image.
 *
 !pyproject.toml
 !uv.lock
+!pipeline/
+!pipeline/**
 !tests/
 !tests/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,106 @@ jobs:
           path: test-results/report.html
           retention-days: 30
 
+  # Extract -> transform -> load -> serve. The pytest run above already
+  # extracted this run's raw artifacts; this job transforms them into one
+  # canonical record, loads it into the durable store (an orphan
+  # metrics-data branch, one JSON per run, partitioned by date), and
+  # serves the whole history as a GitHub Pages dashboard. Runs even when
+  # the test job failed, on purpose: a failed run is a data point the
+  # trend should show, not a gap. The store is git, so history survives
+  # the 30-day artifact retention that would otherwise erase it.
+  publish:
+    name: Publish metrics and dashboard
+    runs-on: ubuntu-latest
+    needs: test
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    # Serialize store writes so a re-run racing the next scheduled run
+    # cannot interleave two pushes to metrics-data and lose one.
+    concurrency:
+      group: metrics-store
+      cancel-in-progress: false
+    permissions:
+      contents: write # push run records to the metrics-data branch
+      pages: write # deploy the dashboard
+      id-token: write # required by deploy-pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      STORE_BRANCH: metrics-data
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv and Python 3.12.13
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          python-version: "3.12.13"
+
+      - run: uv sync --locked
+
+      # This run's raw artifacts come from the test job. Tolerate their
+      # absence: a run that died before uploading still gets a record,
+      # keyed off the CI run id, so the outage is visible in the history.
+      - name: Download this run's test results
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: test-results
+          path: test-results
+
+      - name: Transform and load the run record into the store
+        run: |
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Clone the store branch, or start it as an empty orphan on the
+          # very first run so this bootstraps without manual setup.
+          if git clone -q --branch "$STORE_BRANCH" --single-branch "$repo_url" store; then
+            echo "Checked out existing $STORE_BRANCH"
+          else
+            rm -rf store
+            git clone -q --depth 1 --single-branch "$repo_url" store
+            git -C store checkout -q --orphan "$STORE_BRANCH"
+            git -C store rm -rq --cached -- . || true
+            find store -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            echo "Initialized new $STORE_BRANCH"
+          fi
+
+          # TRANSFORM + LOAD: normalize the artifacts into a record under
+          # the store, keyed by run id so a re-run overwrites in place.
+          uv run python -m pipeline.transform --results-dir test-results --store-dir store
+
+          git -C store add runs
+          if git -C store diff --cached --quiet; then
+            echo "Record already present; store unchanged (idempotent re-run)"
+          else
+            git -C store commit -q -m "data: metrics for run ${GITHUB_RUN_ID} (${GITHUB_EVENT_NAME})"
+            git -C store push -q origin "$STORE_BRANCH"
+          fi
+
+      - name: Build the dashboard site
+        run: |
+          set -euo pipefail
+          # SERVE: fold the whole store into history.json beside the
+          # static dashboard, so the page charts all runs, not the latest.
+          mkdir -p site
+          cp dashboard/index.html site/index.html
+          uv run python -m pipeline.aggregate --store-dir store --out site/history.json
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4
+
   # A red X in the Actions tab is not an alert: any scheduled run that
   # does not succeed (failure, timeout, cancellation) opens or updates
   # a single site-down incident issue, and the next passing scheduled

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ test-report.html
 
 # Playwright
 .playwright/
+
+# Local dashboard preview data; the workflow generates this on Pages
+dashboard/history.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,12 @@ RUN uv sync --locked
 # Browser layer: version always matches the locked playwright package.
 RUN uv run playwright install --with-deps chromium
 
+# App code. pipeline/ ships alongside tests/ so pytest collection can
+# import it: `pytest -m smoke` still imports every test module before the
+# marker deselects the non-smoke ones, and tests/pipeline imports the
+# pipeline package. It also lets the container run the transform/aggregate
+# stages, not just the suite.
+COPY pipeline/ ./pipeline/
 COPY tests/ ./tests/
 
 # Report output directory; mount it to keep reports on the host:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Automated QA suite for [kyledarden.com](https://kyledarden.com) built with Playw
 - **Containerized**: Full Docker support for consistent environments
 - **CI/CD ready**: Automated runs twice daily with GitHub Actions
 - **Rich reporting**: HTML test reports auto-generate with screenshots on failure
+- **Trend dashboard**: per-run metrics persisted to a durable store and served as a
+  GitHub Pages uptime/performance dashboard (see [Metrics Pipeline](#metrics-pipeline--trend-dashboard))
 - **Fast & efficient**: Optimized for quick feedback (~2m 30s in CI)
 - **uv-managed**: Fast, modern Python dependency management with a committed lockfile
 - **Fully typed**: Type hints throughout for better IDE support
@@ -163,6 +165,97 @@ Tests run automatically via GitHub Actions:
 Test results and HTML reports are uploaded as artifacts (one per browser on
 push/PR) and retained for 30 days.
 
+## Metrics Pipeline & Trend Dashboard
+
+Artifacts expire after 30 days, so no history survives them. To turn each
+scheduled run into durable trend data, the `publish` job in `tests.yml` runs a
+small end-to-end data pipeline over the run's results and serves the accumulated
+history as a static [GitHub Pages](https://dardenkyle.github.io/site-sentry/)
+dashboard - pass-rate over time, page-load latency trend, and a last-incident
+summary.
+
+```mermaid
+flowchart LR
+  subgraph E["Extract — pytest run"]
+    A["junit.xml<br/>test outcomes"]
+    B["durations.json<br/>timing aggregates"]
+    C["navigation.json<br/>site latency"]
+  end
+  subgraph T["Transform — pipeline.transform"]
+    D["RunRecord<br/>runs/dt=YYYY-MM-DD/run-&lt;id&gt;.json"]
+  end
+  subgraph L["Load — metrics-data branch"]
+    S[("Partitioned<br/>JSON store")]
+  end
+  subgraph SV["Serve — GitHub Pages"]
+    H["history.json<br/>pipeline.aggregate"]
+    G["dashboard/index.html"]
+  end
+  A --> D
+  B --> D
+  C --> D
+  D --> S
+  S --> H --> G
+```
+
+- **Extract**: the pytest run writes three raw artifacts to `test-results/` -
+  `junit.xml` (per-test outcomes), `durations.json` (per-test call durations and
+  aggregates), and `navigation.json` (the site's own first-navigation latency
+  from the Navigation Timing API).
+- **Transform** (`pipeline/transform.py`): joins those into one canonical
+  `RunRecord` keyed by run ID and writes it to a date-partitioned, run-keyed path.
+- **Load**: the record is committed to an orphan **`metrics-data`** branch that
+  serves as the durable store - git as a zero-infra warehouse. The run-keyed
+  filename makes the load idempotent: re-running a workflow overwrites its own
+  record instead of appending a duplicate.
+- **Serve** (`pipeline/aggregate.py` + `dashboard/`): the whole store is folded
+  into one `history.json`, published to GitHub Pages beside the self-contained
+  dashboard, which charts the full history rather than the latest run.
+
+### Run-record schema
+
+Each record is one run, `schema_version`-stamped so old and new records stay
+distinguishable as the shape evolves. Top-level fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `schema_version` | int | Contract version the record was written under |
+| `run_id` | string | CI run ID; the store's dedupe key (`"local"` off CI) |
+| `run_number` | int \| null | Human-facing CI run number |
+| `timestamp` | string | ISO-8601 UTC instant the metrics were written |
+| `trigger` | string | What started the run (`schedule`, `workflow_dispatch`, …) |
+| `browser` | string \| null | Engine the run exercised |
+| `commit_sha` | string \| null | Commit the run tested |
+| `counts` | object | Pass/fail tally (below) |
+| `duration` | object | Timing aggregates in seconds (below) |
+| `navigation` | object | First-navigation latency in ms (below) |
+| `cases` | array | Per-test `{nodeid, outcome, duration_s}` |
+
+- **`counts`**: `total`, `passed`, `failed`, `errors`, `skipped`, and `pass_rate`
+  (passed / non-skipped; `null` when nothing ran).
+- **`duration`**: `max_s`, `median_s`, `p95_s`, `slow_count`, `retried_count`,
+  and `wall_s` (junit wall time).
+- **`navigation`**: `error` (or `null`), and `ttfb_ms`, `dom_content_loaded_ms`,
+  `load_ms`, `connect_ms` (all `null` on a failed navigation).
+
+### One-time setup
+
+The dashboard deploys via GitHub Pages with **GitHub Actions** as the source
+(repo Settings → Pages → Build and deployment → Source). Until that is enabled
+the pipeline still runs and records still accrue on `metrics-data`; only the
+Pages deploy step is skipped. The store branch bootstraps itself on the first
+scheduled run, so no manual branch creation is needed.
+
+### Running the pipeline locally
+
+```bash
+# After a run has produced test-results/ artifacts:
+uv run python -m pipeline.transform --store-dir store   # write this run's record
+uv run python -m pipeline.aggregate --store-dir store --out dashboard/history.json
+# Then open dashboard/index.html (serve the folder so fetch() works):
+python -m http.server -d dashboard 8000
+```
+
 ## Development
 
 ### Code Quality
@@ -193,12 +286,19 @@ site-sentry/
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml               # Push/PR: lint, type-check, docker, browser-matrix tests
-│       └── tests.yml            # Scheduled QA monitoring (Chromium only) + incident alerts
+│       └── tests.yml            # Scheduled QA monitoring + incident alerts + metrics publish
+├── pipeline/                    # Metrics pipeline (transform + aggregate, stdlib only)
+│   ├── schema.py                # Canonical RunRecord schema
+│   ├── transform.py             # Raw artifacts -> one run record
+│   └── aggregate.py             # Record store -> dashboard history.json
+├── dashboard/
+│   └── index.html               # Self-contained trend dashboard (GitHub Pages)
 ├── tests/
 │   ├── __init__.py
 │   ├── conftest.py              # Pytest configuration
 │   ├── smoke/                   # Smoke tests
 │   ├── ui/                      # UI/navigation tests
+│   ├── pipeline/                # Offline unit tests for the metrics pipeline
 │   └── utils/
 │       ├── __init__.py
 │       └── logger.py            # Logging utility

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,484 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>site-sentry — uptime &amp; performance</title>
+<style>
+  :root {
+    color-scheme: light;
+    --plane:        #f9f9f7;
+    --surface:      #fcfcfb;
+    --text-primary: #0b0b0b;
+    --text-secondary:#52514e;
+    --muted:        #898781;
+    --grid:         #e1e0d9;
+    --axis:         #c3c2b7;
+    --border:       rgba(11,11,11,0.10);
+    --series-1:     #2a78d6; /* TTFB / pass-rate */
+    --series-2:     #eb6834; /* DOM content loaded */
+    --series-3:     #1baf7a; /* load */
+    --good:         #0ca30c;
+    --critical:     #d03b3b;
+    --good-ink:     #006300;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) {
+      color-scheme: dark;
+      --plane:        #0d0d0d;
+      --surface:      #1a1a19;
+      --text-primary: #ffffff;
+      --text-secondary:#c3c2b7;
+      --muted:        #898781;
+      --grid:         #2c2c2a;
+      --axis:         #383835;
+      --border:       rgba(255,255,255,0.10);
+      --series-1:     #3987e5;
+      --series-2:     #d95926;
+      --series-3:     #199e70;
+      --good:         #0ca30c;
+      --critical:     #d03b3b;
+      --good-ink:     #0ca30c;
+    }
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --plane:        #0d0d0d;
+    --surface:      #1a1a19;
+    --text-primary: #ffffff;
+    --text-secondary:#c3c2b7;
+    --muted:        #898781;
+    --grid:         #2c2c2a;
+    --axis:         #383835;
+    --border:       rgba(255,255,255,0.10);
+    --series-1:     #3987e5;
+    --series-2:     #d95926;
+    --series-3:     #199e70;
+    --good-ink:     #0ca30c;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--plane);
+    color: var(--text-primary);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 32px 20px 64px; }
+
+  header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+  h1 { font-size: 1.5rem; margin: 0 0 2px; letter-spacing: -0.01em; }
+  .sub { color: var(--text-secondary); font-size: 0.9rem; margin: 0; }
+  .head-right { display: flex; align-items: center; gap: 12px; }
+
+  .status-badge {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 6px 12px; border-radius: 999px; font-weight: 600; font-size: 0.85rem;
+    border: 1px solid var(--border);
+  }
+  .status-badge .dot { width: 9px; height: 9px; border-radius: 50%; }
+  .status-up   { color: var(--good-ink); }
+  .status-up   .dot { background: var(--good); }
+  .status-down { color: var(--critical); }
+  .status-down .dot { background: var(--critical); }
+
+  .theme-toggle {
+    background: var(--surface); color: var(--text-secondary);
+    border: 1px solid var(--border); border-radius: 8px;
+    width: 34px; height: 34px; cursor: pointer; font-size: 1rem; line-height: 1;
+  }
+  .theme-toggle:hover { color: var(--text-primary); }
+
+  .tiles { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 24px 0; }
+  @media (max-width: 640px) { .tiles { grid-template-columns: repeat(2, 1fr); } }
+  .tile {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 12px; padding: 14px 16px;
+  }
+  .tile .label { color: var(--muted); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; }
+  .tile .value { font-size: 1.55rem; font-weight: 650; margin-top: 4px; }
+  .tile .value small { font-size: 0.85rem; font-weight: 500; color: var(--text-secondary); }
+  .tile .note { color: var(--text-secondary); font-size: 0.78rem; margin-top: 2px; }
+
+  .card {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 12px; padding: 18px 18px 8px; margin-bottom: 20px;
+  }
+  .card h2 { font-size: 0.95rem; margin: 0 0 2px; }
+  .card .cap { color: var(--text-secondary); font-size: 0.82rem; margin: 0 0 6px; }
+  .legend { display: flex; gap: 16px; flex-wrap: wrap; margin: 4px 0 0; padding: 0; list-style: none; font-size: 0.8rem; color: var(--text-secondary); }
+  .legend li { display: flex; align-items: center; gap: 6px; }
+  .legend .swatch { width: 14px; height: 3px; border-radius: 2px; display: inline-block; }
+
+  .chart { width: 100%; height: auto; display: block; overflow: visible; touch-action: none; }
+  .chart text { fill: var(--muted); font-size: 11px; }
+  .chart .axis-line { stroke: var(--axis); stroke-width: 1; }
+  .chart .grid-line { stroke: var(--grid); stroke-width: 1; }
+  .chart .series-line { fill: none; stroke-width: 2; stroke-linejoin: round; stroke-linecap: round; }
+  .chart .end-label { font-weight: 600; font-size: 11px; }
+  .chart .dot { stroke: var(--surface); stroke-width: 1.5; }
+  .chart .incident { fill: var(--critical); stroke: var(--surface); stroke-width: 1.5; }
+
+  .crosshair { stroke: var(--axis); stroke-width: 1; stroke-dasharray: 3 3; visibility: hidden; }
+  .tooltip {
+    position: absolute; pointer-events: none; visibility: hidden;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+    padding: 8px 10px; font-size: 0.78rem; color: var(--text-primary);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.12); min-width: 130px; z-index: 5;
+  }
+  .tooltip .tt-date { color: var(--muted); font-size: 0.72rem; margin-bottom: 4px; }
+  .tooltip .tt-row { display: flex; justify-content: space-between; gap: 12px; font-variant-numeric: tabular-nums; }
+  .tooltip .tt-row .k { color: var(--text-secondary); display: flex; align-items: center; gap: 5px; }
+  .tooltip .tt-row .sw { width: 8px; height: 8px; border-radius: 2px; display: inline-block; }
+
+  .incident-card .none { color: var(--good-ink); font-weight: 600; }
+  .incident-grid { display: grid; grid-template-columns: max-content 1fr; gap: 4px 16px; font-size: 0.86rem; margin-top: 8px; }
+  .incident-grid dt { color: var(--muted); }
+  .incident-grid dd { margin: 0; font-variant-numeric: tabular-nums; }
+  code { background: var(--plane); padding: 1px 5px; border-radius: 5px; font-size: 0.85em; border: 1px solid var(--border); }
+
+  details.table-view { margin-top: 4px; }
+  details.table-view summary { cursor: pointer; color: var(--text-secondary); font-size: 0.85rem; padding: 6px 0; }
+  .table-scroll { overflow-x: auto; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.8rem; margin-top: 8px; }
+  th, td { text-align: right; padding: 6px 10px; border-bottom: 1px solid var(--border); font-variant-numeric: tabular-nums; white-space: nowrap; }
+  th:first-child, td:first-child { text-align: left; }
+  th { color: var(--muted); font-weight: 600; text-transform: uppercase; font-size: 0.68rem; letter-spacing: 0.03em; }
+  td .fail { color: var(--critical); font-weight: 600; }
+  td .ok { color: var(--good-ink); }
+
+  .empty { text-align: center; color: var(--text-secondary); padding: 48px 0; }
+  footer { color: var(--muted); font-size: 0.78rem; margin-top: 28px; text-align: center; }
+  footer a { color: inherit; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <div>
+      <h1>site-sentry</h1>
+      <p class="sub">Uptime &amp; performance trend for <a href="https://kyledarden.com">kyledarden.com</a>, built from the scheduled QA run history.</p>
+    </div>
+    <div class="head-right">
+      <span id="status" class="status-badge"></span>
+      <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark" aria-label="Toggle light/dark theme">◐</button>
+    </div>
+  </header>
+
+  <main id="content"></main>
+
+  <footer>
+    Generated <span id="generated">—</span> · one point per scheduled run ·
+    <a href="https://github.com/dardenkyle/site-sentry">source</a>
+  </footer>
+</div>
+
+<div class="tooltip" id="tooltip"></div>
+
+<script>
+"use strict";
+
+const HISTORY_URL = "./history.json";
+
+const SERIES = [
+  { key: "ttfb_ms",               label: "TTFB",     varname: "--series-1" },
+  { key: "dom_content_loaded_ms", label: "DOM ready",varname: "--series-2" },
+  { key: "load_ms",               label: "Load",     varname: "--series-3" },
+];
+
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function fmtDate(iso, withTime) {
+  const d = new Date(iso);
+  if (isNaN(d)) return iso || "—";
+  const opts = withTime
+    ? { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }
+    : { month: "short", day: "numeric" };
+  return d.toLocaleString(undefined, opts);
+}
+
+function relTime(iso) {
+  const then = new Date(iso).getTime();
+  if (isNaN(then)) return "—";
+  const mins = Math.round((Date.now() - then) / 60000);
+  if (mins < 60) return mins + "m ago";
+  const hrs = Math.round(mins / 60);
+  if (hrs < 48) return hrs + "h ago";
+  return Math.round(hrs / 24) + "d ago";
+}
+
+// Map a mouse event onto the chart's viewBox x coordinate.
+function eventToViewX(svg, evt) {
+  const rect = svg.getBoundingClientRect();
+  const vb = svg.viewBox.baseVal;
+  const clientX = evt.touches ? evt.touches[0].clientX : evt.clientX;
+  return vb.x + ((clientX - rect.left) / rect.width) * vb.width;
+}
+
+const W = 800, H = 300;
+const PAD = { top: 18, right: 64, bottom: 34, left: 46 };
+const PLOT_W = W - PAD.left - PAD.right;
+const PLOT_H = H - PAD.top - PAD.bottom;
+
+// Build one time-series line chart into `mount`. `series` is a list of
+// {key,label,color}; `fmtY` formats axis + tooltip values.
+function lineChart(mount, runs, series, opts) {
+  const svgNS = "http://www.w3.org/2000/svg";
+  const times = runs.map(r => new Date(r.timestamp).getTime());
+  const tMin = Math.min(...times), tMax = Math.max(...times);
+  const tSpan = tMax - tMin || 1;
+
+  let vMin = opts.yMin != null ? opts.yMin : Infinity;
+  let vMax = opts.yMax != null ? opts.yMax : -Infinity;
+  if (opts.yMax == null || opts.yMin == null) {
+    for (const r of runs) {
+      for (const s of series) {
+        const v = r[s.key];
+        if (typeof v === "number") { vMin = Math.min(vMin, v); vMax = Math.max(vMax, v); }
+      }
+    }
+    if (!isFinite(vMin)) { vMin = 0; vMax = 1; }
+    if (opts.yMin == null) vMin = Math.min(vMin, 0);
+    if (vMax === vMin) vMax = vMin + 1;
+    if (opts.yMin == null && opts.yMax == null) vMax += (vMax - vMin) * 0.08;
+  }
+
+  const x = t => PAD.left + ((t - tMin) / tSpan) * PLOT_W;
+  const y = v => PAD.top + PLOT_H - ((v - vMin) / (vMax - vMin)) * PLOT_H;
+
+  const svg = document.createElementNS(svgNS, "svg");
+  svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+  svg.setAttribute("class", "chart");
+  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+  svg.setAttribute("role", "img");
+
+  const mk = (name, attrs, text) => {
+    const el = document.createElementNS(svgNS, name);
+    for (const k in attrs) el.setAttribute(k, attrs[k]);
+    if (text != null) el.textContent = text;
+    return el;
+  };
+
+  // Y gridlines + labels
+  const ticks = 4;
+  for (let i = 0; i <= ticks; i++) {
+    const v = vMin + (i / ticks) * (vMax - vMin);
+    const yy = y(v);
+    svg.appendChild(mk("line", { class: "grid-line", x1: PAD.left, y1: yy, x2: PAD.left + PLOT_W, y2: yy }));
+    svg.appendChild(mk("text", { x: PAD.left - 8, y: yy + 3.5, "text-anchor": "end" }, opts.fmtY(v)));
+  }
+
+  // X axis date ticks (up to 6, evenly across the span)
+  const xTicks = Math.min(6, runs.length);
+  for (let i = 0; i < xTicks; i++) {
+    const t = tMin + (xTicks === 1 ? 0.5 : i / (xTicks - 1)) * tSpan;
+    svg.appendChild(mk("text", { x: x(t), y: H - 12, "text-anchor": "middle" }, fmtDate(new Date(t).toISOString(), false)));
+  }
+  svg.appendChild(mk("line", { class: "axis-line", x1: PAD.left, y1: PAD.top + PLOT_H, x2: PAD.left + PLOT_W, y2: PAD.top + PLOT_H }));
+
+  // Series lines + end labels + dots
+  for (const s of series) {
+    const pts = runs.map((r, i) => ({ v: r[s.key], t: times[i], run: r }))
+                    .filter(p => typeof p.v === "number");
+    if (!pts.length) continue;
+    const d = pts.map((p, i) => `${i ? "L" : "M"}${x(p.t).toFixed(1)},${y(p.v).toFixed(1)}`).join(" ");
+    svg.appendChild(mk("path", { class: "series-line", d, stroke: s.color }));
+    const last = pts[pts.length - 1];
+    svg.appendChild(mk("text", {
+      class: "end-label", x: x(last.t) + 8, y: y(last.v) + 3.5, fill: s.color, "text-anchor": "start"
+    }, series.length > 1 ? s.label : opts.fmtY(last.v)));
+  }
+  // Incident markers on the first series baseline row
+  runs.forEach((r, i) => {
+    if (r.__incident) {
+      svg.appendChild(mk("circle", { class: "incident", cx: x(times[i]), cy: PAD.top + PLOT_H, r: 4 }));
+    }
+  });
+
+  // Hover crosshair + focus dots
+  const crosshair = mk("line", { class: "crosshair", y1: PAD.top, y2: PAD.top + PLOT_H });
+  svg.appendChild(crosshair);
+  const focus = series.map(s => {
+    const c = mk("circle", { class: "dot", r: 4, fill: s.color, visibility: "hidden" });
+    svg.appendChild(c);
+    return c;
+  });
+
+  const tooltip = document.getElementById("tooltip");
+  function onMove(evt) {
+    const vx = eventToViewX(svg, evt);
+    // nearest run by time
+    let best = 0, bestDx = Infinity;
+    times.forEach((t, i) => { const dx = Math.abs(x(t) - vx); if (dx < bestDx) { bestDx = dx; best = i; } });
+    const r = runs[best];
+    crosshair.setAttribute("x1", x(times[best]));
+    crosshair.setAttribute("x2", x(times[best]));
+    crosshair.style.visibility = "visible";
+    let rows = "";
+    series.forEach((s, si) => {
+      const v = r[s.key];
+      if (typeof v === "number") {
+        focus[si].setAttribute("cx", x(times[best]));
+        focus[si].setAttribute("cy", y(v));
+        focus[si].style.visibility = "visible";
+        rows += `<div class="tt-row"><span class="k"><span class="sw" style="background:${s.color}"></span>${s.label}</span><span>${opts.fmtY(v)}</span></div>`;
+      } else {
+        focus[si].style.visibility = "hidden";
+      }
+    });
+    tooltip.innerHTML = `<div class="tt-date">${fmtDate(r.timestamp, true)}</div>${rows}`;
+    tooltip.style.visibility = "visible";
+    const svgRect = svg.getBoundingClientRect();
+    const px = svgRect.left + (x(times[best]) / W) * svgRect.width;
+    tooltip.style.left = Math.round(px + 14) + "px";
+    tooltip.style.top = Math.round(window.scrollY + svgRect.top + 10) + "px";
+  }
+  function onLeave() {
+    crosshair.style.visibility = "hidden";
+    focus.forEach(f => f.style.visibility = "hidden");
+    tooltip.style.visibility = "hidden";
+  }
+  svg.addEventListener("mousemove", onMove);
+  svg.addEventListener("mouseleave", onLeave);
+  svg.addEventListener("touchstart", onMove, { passive: true });
+  svg.addEventListener("touchmove", onMove, { passive: true });
+  svg.addEventListener("touchend", onLeave);
+
+  mount.appendChild(svg);
+}
+
+function resolveColors(series) {
+  return series.map(s => ({ ...s, color: cssVar(s.varname) }));
+}
+
+function renderStatus(history) {
+  const el = document.getElementById("status");
+  const runs = history.runs || [];
+  const last = runs[runs.length - 1];
+  const down = last && (last.failed > 0 || last.errors > 0 || last.nav_error);
+  el.className = "status-badge " + (down ? "status-down" : "status-up");
+  el.innerHTML = `<span class="dot"></span>${down ? "Site down" : "Operational"}`;
+  if (!last) { el.className = "status-badge"; el.textContent = "No data"; }
+}
+
+function tile(label, value, note) {
+  return `<div class="tile"><div class="label">${label}</div><div class="value">${value}</div><div class="note">${note || ""}</div></div>`;
+}
+
+function renderTiles(history) {
+  const runs = history.runs || [];
+  const last = runs[runs.length - 1] || {};
+  const passRate = last.pass_rate != null ? Math.round(last.pass_rate * 1000) / 10 + "%" : "—";
+  const dcl = typeof last.dom_content_loaded_ms === "number" ? Math.round(last.dom_content_loaded_ms) + "<small> ms</small>" : "—";
+  const inc = history.last_incident;
+  const incNote = inc ? relTime(inc.timestamp) : "none on record";
+  const incVal = inc ? fmtDate(inc.timestamp, false) : "None";
+  return `<section class="tiles">
+    ${tile("Latest pass rate", passRate, last.passed != null ? `${last.passed}/${last.total} tests` : "")}
+    ${tile("Latest DOM ready", dcl, "first navigation")}
+    ${tile("Runs tracked", history.run_count ?? runs.length, "scheduled QA runs")}
+    ${tile("Last incident", incVal, incNote)}
+  </section>`;
+}
+
+function legendHtml(series) {
+  return `<ul class="legend">${series.map(s =>
+    `<li><span class="swatch" style="background:${s.color}"></span>${s.label}</li>`).join("")}</ul>`;
+}
+
+function renderIncident(history) {
+  const inc = history.last_incident;
+  if (!inc) {
+    return `<div class="card incident-card"><h2>Last incident</h2><p class="none">✓ No incident on record — every tracked run passed.</p></div>`;
+  }
+  const reason = inc.nav_error ? `Navigation failed: ${inc.nav_error}`
+    : `${inc.failed || 0} failed, ${inc.errors || 0} errored`;
+  return `<div class="card incident-card">
+    <h2>Last incident</h2>
+    <dl class="incident-grid">
+      <dt>When</dt><dd>${fmtDate(inc.timestamp, true)} (${relTime(inc.timestamp)})</dd>
+      <dt>What</dt><dd>${reason}</dd>
+      <dt>Pass rate</dt><dd>${inc.pass_rate != null ? Math.round(inc.pass_rate * 1000) / 10 + "%" : "—"}</dd>
+      <dt>Run</dt><dd>${inc.run_number != null ? "#" + inc.run_number : "—"}${inc.commit_sha ? " · <code>" + inc.commit_sha.slice(0, 7) + "</code>" : ""}</dd>
+    </dl></div>`;
+}
+
+function tableView(runs) {
+  const rows = runs.slice().reverse().map(r => {
+    const down = r.failed > 0 || r.errors > 0 || r.nav_error;
+    return `<tr>
+      <td>${fmtDate(r.timestamp, true)}</td>
+      <td class="${down ? "fail" : "ok"}">${down ? "down" : "up"}</td>
+      <td>${r.pass_rate != null ? Math.round(r.pass_rate * 1000) / 10 + "%" : "—"}</td>
+      <td>${r.passed ?? "—"}/${r.total ?? "—"}</td>
+      <td>${num(r.ttfb_ms)}</td>
+      <td>${num(r.dom_content_loaded_ms)}</td>
+      <td>${num(r.load_ms)}</td>
+    </tr>`;
+  }).join("");
+  return `<details class="table-view"><summary>View all runs as a table</summary>
+    <div class="table-scroll"><table>
+      <thead><tr><th>Run</th><th>Status</th><th>Pass</th><th>Tests</th><th>TTFB ms</th><th>DOM ms</th><th>Load ms</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table></div></details>`;
+}
+function num(v) { return typeof v === "number" ? Math.round(v) : "—"; }
+
+function render(history) {
+  document.getElementById("generated").textContent = history.generated_at ? fmtDate(history.generated_at, true) : "—";
+  const content = document.getElementById("content");
+  const runs = (history.runs || []).filter(r => r.timestamp);
+  renderStatus(history);
+
+  if (!runs.length) {
+    content.innerHTML = `<div class="empty">No scheduled runs recorded yet. The dashboard fills in as the twice-daily QA workflow publishes run records.</div>`;
+    return;
+  }
+  // Flag incidents so the charts can mark them.
+  runs.forEach(r => { r.__incident = r.failed > 0 || r.errors > 0 || !!r.nav_error; });
+
+  const perfSeries = resolveColors(SERIES);
+  content.innerHTML = renderTiles(history)
+    + `<div class="card" id="pass-card"><h2>Pass rate over time</h2><p class="cap">Share of non-skipped tests passing, per scheduled run. Red marks flag runs with a failure.</p></div>`
+    + `<div class="card" id="perf-card"><h2>Page-load latency trend</h2><p class="cap">The site's own timings for the session's first navigation, from the Navigation Timing API.</p>${legendHtml(perfSeries)}</div>`
+    + renderIncident(history)
+    + tableView(runs);
+
+  lineChart(document.getElementById("pass-card"), runs,
+    [{ key: "pass_rate", label: "Pass rate", color: cssVar("--series-1") }],
+    { yMin: 0, yMax: 1, fmtY: v => Math.round(v * 100) + "%" });
+
+  lineChart(document.getElementById("perf-card"), runs, perfSeries,
+    { yMin: 0, fmtY: v => Math.round(v) + " ms" });
+}
+
+function applyStoredTheme() {
+  const saved = localStorage.getItem("ss-theme");
+  if (saved) document.documentElement.setAttribute("data-theme", saved);
+}
+document.getElementById("theme-toggle").addEventListener("click", () => {
+  const root = document.documentElement;
+  const isDark = root.getAttribute("data-theme") === "dark"
+    || (!root.getAttribute("data-theme") && matchMedia("(prefers-color-scheme: dark)").matches);
+  const next = isDark ? "light" : "dark";
+  root.setAttribute("data-theme", next);
+  localStorage.setItem("ss-theme", next);
+  if (window.__history) render(window.__history); // recolor with new theme vars
+});
+
+applyStoredTheme();
+fetch(HISTORY_URL)
+  .then(r => { if (!r.ok) throw new Error(r.status); return r.json(); })
+  .then(history => { window.__history = history; render(history); })
+  .catch(() => {
+    document.getElementById("content").innerHTML =
+      `<div class="empty">Could not load run history (history.json). Once the scheduled workflow publishes, trends appear here.</div>`;
+    document.getElementById("status").textContent = "";
+  });
+</script>
+</body>
+</html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -192,9 +192,18 @@ function cssVar(name) {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
 }
 
+// history.json is external input (fetched, and committed by CI from
+// Playwright error text and git metadata). Escape any string from it
+// before it lands in innerHTML so a tampered or unusual value - a nav
+// error carrying markup, say - cannot inject into the page.
+function esc(s) {
+  return String(s == null ? "" : s).replace(/[&<>"']/g, c =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
 function fmtDate(iso, withTime) {
   const d = new Date(iso);
-  if (isNaN(d)) return iso || "—";
+  if (isNaN(d)) return esc(iso || "—");
   const opts = withTime
     ? { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }
     : { month: "short", day: "numeric" };
@@ -395,7 +404,7 @@ function renderIncident(history) {
   if (!inc) {
     return `<div class="card incident-card"><h2>Last incident</h2><p class="none">✓ No incident on record — every tracked run passed.</p></div>`;
   }
-  const reason = inc.nav_error ? `Navigation failed: ${inc.nav_error}`
+  const reason = inc.nav_error ? `Navigation failed: ${esc(inc.nav_error)}`
     : `${inc.failed || 0} failed, ${inc.errors || 0} errored`;
   return `<div class="card incident-card">
     <h2>Last incident</h2>
@@ -403,7 +412,7 @@ function renderIncident(history) {
       <dt>When</dt><dd>${fmtDate(inc.timestamp, true)} (${relTime(inc.timestamp)})</dd>
       <dt>What</dt><dd>${reason}</dd>
       <dt>Pass rate</dt><dd>${inc.pass_rate != null ? Math.round(inc.pass_rate * 1000) / 10 + "%" : "—"}</dd>
-      <dt>Run</dt><dd>${inc.run_number != null ? "#" + inc.run_number : "—"}${inc.commit_sha ? " · <code>" + inc.commit_sha.slice(0, 7) + "</code>" : ""}</dd>
+      <dt>Run</dt><dd>${inc.run_number != null ? "#" + inc.run_number : "—"}${inc.commit_sha ? " · <code>" + esc(String(inc.commit_sha).slice(0, 7)) + "</code>" : ""}</dd>
     </dl></div>`;
 }
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,0 +1,12 @@
+"""Metrics pipeline for Site Sentry.
+
+Turns the raw artifacts each QA run emits (junit.xml, durations.json,
+navigation.json) into one normalized run record, and folds a directory
+of those records into the history the trend dashboard reads. This is the
+transform and serve half of the extract -> transform -> load -> serve
+pipeline described in issue #33; extraction happens in the pytest run
+itself, loading is the workflow committing records to the store.
+
+Stdlib only and no pytest/Playwright imports, so the pipeline runs as a
+plain script in CI without the test toolchain installed.
+"""

--- a/pipeline/aggregate.py
+++ b/pipeline/aggregate.py
@@ -41,7 +41,10 @@ def load_records(store_dir: Path) -> list[dict[str, Any]]:
     for path in sorted(store_dir.glob(RUNS_GLOB)):
         try:
             loaded = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            # A half-written record can be invalid UTF-8, not just invalid
+            # JSON; catching UnicodeDecodeError too keeps one truncated
+            # partition from aborting the whole aggregation.
             loaded = None
         if isinstance(loaded, dict):
             records.append(loaded)

--- a/pipeline/aggregate.py
+++ b/pipeline/aggregate.py
@@ -1,0 +1,208 @@
+"""Fold the store of run records into the history the dashboard reads.
+
+The store holds one record per run, partitioned by date. The dashboard
+needs a single time-ordered series, not a directory tree, so this stage
+reads every record, flattens each to the handful of fields a chart plots
+(dropping the per-test case list the trend view never uses), and writes
+one history.json.
+
+Records are deduplicated on run_id keeping the latest timestamp, so a
+re-run that rewrote its record cannot double-count in the history even if
+a stale copy lingers. Stdlib only.
+"""
+
+import argparse
+import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pipeline.schema import SCHEMA_VERSION
+
+DEFAULT_STORE_DIR = "test-results"
+RUNS_GLOB = "runs/**/*.json"
+HISTORY_NAME = "history.json"
+
+
+def load_records(store_dir: Path) -> list[dict[str, Any]]:
+    """Read every run record under a store directory.
+
+    Corrupt or non-object files are skipped rather than aborting the
+    aggregation: one unreadable partition should not blank the dashboard.
+
+    Args:
+        store_dir: Root the partitioned records live under
+
+    Returns:
+        The parsed record objects, in filesystem-glob order
+    """
+    records: list[dict[str, Any]] = []
+    for path in sorted(store_dir.glob(RUNS_GLOB)):
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            loaded = None
+        if isinstance(loaded, dict):
+            records.append(loaded)
+    return records
+
+
+def to_series_entry(record: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a run record to the fields the dashboard charts.
+
+    The nested record is convenient to write but awkward to plot; this
+    projects it to a flat row (pass rate, load timings, timing
+    aggregates) and drops the per-test case list, which the trend view
+    never reads.
+
+    Args:
+        record: One parsed run record
+
+    Returns:
+        A flat dict of the chartable fields for one run
+    """
+    counts = record.get("counts") or {}
+    duration = record.get("duration") or {}
+    navigation = record.get("navigation") or {}
+    return {
+        "run_id": record.get("run_id"),
+        "run_number": record.get("run_number"),
+        "timestamp": record.get("timestamp"),
+        "trigger": record.get("trigger"),
+        "browser": record.get("browser"),
+        "commit_sha": record.get("commit_sha"),
+        "total": counts.get("total"),
+        "passed": counts.get("passed"),
+        "failed": counts.get("failed"),
+        "errors": counts.get("errors"),
+        "pass_rate": counts.get("pass_rate"),
+        "ttfb_ms": navigation.get("ttfb_ms"),
+        "dom_content_loaded_ms": navigation.get("dom_content_loaded_ms"),
+        "load_ms": navigation.get("load_ms"),
+        "nav_error": navigation.get("error"),
+        "p95_s": duration.get("p95_s"),
+        "max_s": duration.get("max_s"),
+        "wall_s": duration.get("wall_s"),
+        "slow_count": duration.get("slow_count"),
+        "retried_count": duration.get("retried_count"),
+    }
+
+
+def dedupe_by_run(entries: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse entries sharing a run_id, keeping the latest timestamp.
+
+    The store already keys files by run_id, so this defends against a
+    stale duplicate rather than routine collisions: whichever copy has
+    the newer timestamp wins, matching the idempotency the pipeline
+    promises. The result is sorted ascending by timestamp so the series
+    reads left-to-right as time.
+
+    Args:
+        entries: Flattened run entries in any order
+
+    Returns:
+        One entry per run_id, sorted oldest run first
+    """
+    latest: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        run_id = str(entry.get("run_id"))
+        prior = latest.get(run_id)
+        if prior is None or str(entry.get("timestamp")) >= str(prior.get("timestamp")):
+            latest[run_id] = entry
+    return sorted(latest.values(), key=lambda e: str(e.get("timestamp")))
+
+
+def _is_incident(entry: dict[str, Any]) -> bool:
+    """Decide whether a run entry counts as an incident.
+
+    An incident is a run that failed to prove the site healthy: a test
+    failed or errored, or the site's first navigation itself failed. A
+    run of only skips is not an incident (it asserted nothing), which is
+    why the test check reads the failure counts, not the pass rate.
+
+    Args:
+        entry: A flattened run entry
+
+    Returns:
+        True when the run failed a test, errored, or could not navigate
+    """
+    failed = entry.get("failed") or 0
+    errors = entry.get("errors") or 0
+    return failed > 0 or errors > 0 or entry.get("nav_error") is not None
+
+
+def last_incident(entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Find the most recent incident in a time-ascending series.
+
+    Args:
+        entries: Run entries sorted oldest first
+
+    Returns:
+        The latest entry that is an incident, or None if all were healthy
+    """
+    incidents = [e for e in entries if _is_incident(e)]
+    return incidents[-1] if incidents else None
+
+
+def build_history(records: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    """Build the dashboard's history document from raw records.
+
+    Args:
+        records: Parsed run records from the store
+
+    Returns:
+        A history document: metadata, the deduped time-ordered run
+        series, and the last-incident summary
+    """
+    runs = dedupe_by_run(to_series_entry(r) for r in records)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "run_count": len(runs),
+        "runs": runs,
+        "last_incident": last_incident(runs),
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse the aggregate CLI arguments.
+
+    Args:
+        argv: Argument list, or None to read from sys.argv
+
+    Returns:
+        Parsed arguments with store_dir and out path
+    """
+    parser = argparse.ArgumentParser(description="Fold run records into history.json.")
+    parser.add_argument(
+        "--store-dir",
+        type=Path,
+        default=Path(DEFAULT_STORE_DIR),
+        help="Root the partitioned run records live under",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path(DEFAULT_STORE_DIR) / HISTORY_NAME,
+        help="Path to write the history document to",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Read the store and write history.json for the dashboard.
+
+    Args:
+        argv: Argument list, or None to read from sys.argv
+    """
+    args = _parse_args(argv)
+    history = build_history(load_records(args.store_dir))
+    out_path: Path = args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(history, indent=2) + "\n", encoding="utf-8")
+    print(f"{out_path} ({history['run_count']} runs)")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -1,0 +1,149 @@
+"""Canonical schema for a single QA run record.
+
+One RunRecord is the unit the store holds and the dashboard charts: it
+joins test outcomes (from junit.xml), timing aggregates (from
+durations.json), and the site's measured latency (from navigation.json)
+into one row keyed by run_id. The dataclasses here are the documented
+contract for that row; SCHEMA_VERSION is bumped whenever a field's
+meaning changes so old and new records in the store stay distinguishable.
+
+The dashboard and the aggregate stage read records back as plain JSON
+dicts, so only the write direction (to_dict) lives here; the field names
+below are the schema those readers depend on.
+"""
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+# Bump when a field is renamed, removed, or has its meaning changed, so a
+# record written under an old contract is never silently misread. Adding
+# an optional field is backwards compatible and does not require a bump.
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class TestCase:
+    """Outcome and call-phase duration of one test in the run.
+
+    Attributes:
+        nodeid: Test identity as classname::name from the junit report
+        outcome: One of passed, failed, error, skipped
+        duration_s: Call-phase duration in seconds, from the junit time
+    """
+
+    nodeid: str
+    outcome: str
+    duration_s: float
+
+
+@dataclass(frozen=True)
+class TestCounts:
+    """Aggregate pass/fail tally for the run.
+
+    pass_rate excludes skips from the denominator: a skipped test made no
+    assertion about the site, so counting it as neither pass nor fail
+    keeps the rate a statement about tests that actually ran. A run with
+    nothing but skips has an undefined rate, reported as None.
+
+    Attributes:
+        total: Every testcase in the report, skips included
+        passed: Tests that passed
+        failed: Tests with a failure (assertion) result
+        errors: Tests with an error (collection or fixture crash) result
+        skipped: Tests that were skipped
+        pass_rate: passed / (passed + failed + errors), or None when that
+            denominator is zero
+    """
+
+    total: int
+    passed: int
+    failed: int
+    errors: int
+    skipped: int
+    pass_rate: float | None
+
+
+@dataclass(frozen=True)
+class DurationStats:
+    """Timing aggregates for the run, in seconds.
+
+    Sourced from durations.json (per-test call-phase durations, worst
+    attempt) except wall_s, which is the junit testsuite wall time.
+
+    Attributes:
+        max_s: Slowest single test
+        median_s: Median test duration
+        p95_s: 95th-percentile test duration
+        slow_count: Tests over the slow threshold
+        retried_count: Tests that took more than one attempt
+        wall_s: Total wall-clock time of the run, or None if unknown
+    """
+
+    max_s: float | None
+    median_s: float | None
+    p95_s: float | None
+    slow_count: int | None
+    retried_count: int | None
+    wall_s: float | None
+
+
+@dataclass(frozen=True)
+class NavigationStats:
+    """The site's own latency for the session's first navigation.
+
+    Milliseconds from navigation start, measured by the browser via the
+    Navigation Timing API (see tests/utils/timing.py). All timings are
+    None when the navigation failed; error then carries why.
+
+    Attributes:
+        error: Navigation error message, or None when it completed
+        ttfb_ms: Time to first byte
+        dom_content_loaded_ms: domContentLoaded mark
+        load_ms: load mark, all initial subresources done
+        connect_ms: TCP + TLS connection established
+    """
+
+    error: str | None
+    ttfb_ms: float | None
+    dom_content_loaded_ms: float | None
+    load_ms: float | None
+    connect_ms: float | None
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    """One QA run, normalized across all of its raw artifacts.
+
+    Attributes:
+        schema_version: The SCHEMA_VERSION this record was written under
+        run_id: CI run id, the store's dedupe key ("local" off CI)
+        run_number: Human-facing CI run number, or None off CI
+        timestamp: ISO-8601 UTC instant the run's metrics were written
+        trigger: What started the run (schedule, push, workflow_dispatch)
+        browser: Engine the run exercised
+        commit_sha: Commit the run tested, or None off CI
+        counts: Pass/fail tally
+        duration: Timing aggregates
+        navigation: Site latency for the first navigation
+        cases: Per-test outcomes and durations
+    """
+
+    schema_version: int
+    run_id: str
+    run_number: int | None
+    timestamp: str
+    trigger: str
+    browser: str | None
+    commit_sha: str | None
+    counts: TestCounts
+    duration: DurationStats
+    navigation: NavigationStats
+    cases: list[TestCase]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the JSON-ready dict stored and charted.
+
+        Returns:
+            A nested dict mirroring this record's fields, JSON-encodable
+        """
+        return asdict(self)

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -52,7 +52,10 @@ def load_json(path: Path) -> dict[str, Any] | None:
     result: dict[str, Any] | None = None
     try:
         loaded = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        # A half-written file can be invalid UTF-8, not just invalid JSON;
+        # UnicodeDecodeError from read_text must be swallowed too, or a
+        # truncated artifact crashes the transform instead of degrading.
         loaded = None
     if isinstance(loaded, dict):
         result = loaded

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -1,0 +1,301 @@
+"""Transform a run's raw artifacts into one canonical run record.
+
+Reads the three artifacts a QA run leaves in test-results/ - junit.xml
+(test outcomes), durations.json (timing aggregates), navigation.json
+(site latency) - and normalizes them into a RunRecord keyed by run_id.
+The record is written to a partitioned path (runs/dt=YYYY-MM-DD/run-<id>)
+so the load stage can commit it to the store without collisions, and the
+run_id filename makes a re-run overwrite in place rather than duplicate.
+
+Each input is optional: a run that died before pytest wrote junit.xml
+still yields a record (with empty counts) rather than nothing, so an
+outage is visible in the history instead of being a gap. Stdlib only.
+"""
+
+import argparse
+import json
+import os
+import xml.etree.ElementTree as ET
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pipeline.schema import (
+    SCHEMA_VERSION,
+    DurationStats,
+    NavigationStats,
+    RunRecord,
+    TestCase,
+    TestCounts,
+)
+
+DEFAULT_RESULTS_DIR = "test-results"
+JUNIT_NAME = "junit.xml"
+DURATIONS_NAME = "durations.json"
+NAVIGATION_NAME = "navigation.json"
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    """Read a JSON object from disk, tolerating absence and corruption.
+
+    A missing or malformed artifact means the run died before writing it,
+    which is a data point (an incomplete run), not a crash for the
+    pipeline. Both cases return None so the caller records what it has.
+
+    Args:
+        path: Path to a JSON file expected to hold an object
+
+    Returns:
+        The parsed object, or None when the file is missing or unreadable
+    """
+    result: dict[str, Any] | None = None
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        loaded = None
+    if isinstance(loaded, dict):
+        result = loaded
+    return result
+
+
+def parse_junit(root: ET.Element) -> tuple[TestCounts, list[TestCase], float | None]:
+    """Extract counts, per-test cases, and wall time from a junit tree.
+
+    Counts are derived from the testcases themselves rather than the
+    testsuite attributes, so they can never disagree with the per-test
+    list the record also carries. Wall time sums every testsuite's time
+    attribute to stay correct if pytest ever emits more than one suite.
+
+    Args:
+        root: Parsed junit root, a <testsuites> or bare <testsuite>
+
+    Returns:
+        The pass/fail counts, the per-test cases, and total wall seconds
+        (None when no testsuite carried a time attribute)
+    """
+    cases: list[TestCase] = []
+    for case in root.iter("testcase"):
+        classname = case.get("classname") or ""
+        name = case.get("name") or ""
+        nodeid = f"{classname}::{name}" if classname else name
+        if case.find("failure") is not None:
+            outcome = "failed"
+        elif case.find("error") is not None:
+            outcome = "error"
+        elif case.find("skipped") is not None:
+            outcome = "skipped"
+        else:
+            outcome = "passed"
+        cases.append(TestCase(nodeid, outcome, round(float(case.get("time") or 0.0), 3)))
+    passed = sum(1 for c in cases if c.outcome == "passed")
+    failed = sum(1 for c in cases if c.outcome == "failed")
+    errors = sum(1 for c in cases if c.outcome == "error")
+    skipped = sum(1 for c in cases if c.outcome == "skipped")
+    ran = passed + failed + errors
+    counts = TestCounts(
+        total=len(cases),
+        passed=passed,
+        failed=failed,
+        errors=errors,
+        skipped=skipped,
+        pass_rate=round(passed / ran, 4) if ran else None,
+    )
+    suite_times = [float(t) for s in root.iter("testsuite") if (t := s.get("time"))]
+    wall_s = round(sum(suite_times), 3) if suite_times else None
+    return counts, cases, wall_s
+
+
+def duration_stats(durations: dict[str, Any] | None, wall_s: float | None) -> DurationStats:
+    """Map durations.json aggregates onto DurationStats.
+
+    Args:
+        durations: Parsed durations.json, or None when it is absent
+        wall_s: Wall time from the junit report, carried in here
+
+    Returns:
+        The run's timing aggregates, all None when durations is absent
+    """
+    data = durations or {}
+    return DurationStats(
+        max_s=data.get("max_duration"),
+        median_s=data.get("median_duration"),
+        p95_s=data.get("p95_duration"),
+        slow_count=data.get("slow_count"),
+        retried_count=data.get("retried_count"),
+        wall_s=wall_s,
+    )
+
+
+def navigation_stats(navigation: dict[str, Any] | None) -> NavigationStats:
+    """Map navigation.json onto NavigationStats.
+
+    Args:
+        navigation: Parsed navigation.json, or None when it is absent
+
+    Returns:
+        The site's first-navigation latency, all timings None on a failed
+        or absent navigation
+    """
+    nav = (navigation or {}).get("navigation") or {}
+    timing = nav.get("timing") or {}
+    return NavigationStats(
+        error=nav.get("error"),
+        ttfb_ms=timing.get("ttfb_ms"),
+        dom_content_loaded_ms=timing.get("dom_content_loaded_ms"),
+        load_ms=timing.get("load_ms"),
+        connect_ms=timing.get("connect_ms"),
+    )
+
+
+def _run_identity(
+    durations: dict[str, Any] | None, navigation: dict[str, Any] | None
+) -> tuple[str, int | None, str]:
+    """Resolve run_id, run_number, and timestamp from whichever artifact has them.
+
+    Both metrics files carry the same identity block (conftest writes it
+    from one helper), so either answers; durations is preferred and
+    navigation is the fallback for a run that wrote only one. A run that
+    wrote neither is stamped now with a local id so it still records.
+
+    Args:
+        durations: Parsed durations.json, or None
+        navigation: Parsed navigation.json, or None
+
+    Returns:
+        The run id, run number (or None), and ISO-8601 UTC timestamp
+    """
+    for src in (durations, navigation):
+        if src and src.get("run_id") and src.get("timestamp"):
+            return src["run_id"], src.get("run_number"), src["timestamp"]
+    return "local", None, datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def build_run_record(
+    durations: dict[str, Any] | None,
+    navigation: dict[str, Any] | None,
+    junit_root: ET.Element | None,
+    env: Mapping[str, str],
+) -> RunRecord:
+    """Assemble one RunRecord from a run's parsed artifacts.
+
+    Pure over its inputs (env is passed in, not read from the process) so
+    a run's normalization can be pinned in a test without CI or a live
+    site. trigger and commit come from the CI environment; everything
+    else comes from the artifacts.
+
+    Args:
+        durations: Parsed durations.json, or None when absent
+        navigation: Parsed navigation.json, or None when absent
+        junit_root: Parsed junit root, or None when the report is unusable
+        env: Environment mapping, read for GITHUB_EVENT_NAME/GITHUB_SHA
+
+    Returns:
+        The normalized record for the run
+    """
+    if junit_root is not None:
+        counts, cases, wall_s = parse_junit(junit_root)
+    else:
+        counts, cases, wall_s = TestCounts(0, 0, 0, 0, 0, None), [], None
+    run_id, run_number, timestamp = _run_identity(durations, navigation)
+    return RunRecord(
+        schema_version=SCHEMA_VERSION,
+        run_id=run_id,
+        run_number=run_number,
+        timestamp=timestamp,
+        trigger=env.get("GITHUB_EVENT_NAME", "local"),
+        browser=(navigation or {}).get("browser"),
+        commit_sha=env.get("GITHUB_SHA") or None,
+        counts=counts,
+        duration=duration_stats(durations, wall_s),
+        navigation=navigation_stats(navigation),
+        cases=cases,
+    )
+
+
+def partition_path(record: RunRecord) -> Path:
+    """Compute the store-relative path a record is written to.
+
+    Partitioned by run date (dt=YYYY-MM-DD) so the store stays scannable
+    as it grows, and named by run_id so a re-run of the same workflow
+    overwrites its own record instead of appending a duplicate - the
+    idempotency the pipeline promises.
+
+    Args:
+        record: The record whose partition path to compute
+
+    Returns:
+        A relative path like runs/dt=2026-07-20/run-12345.json
+    """
+    date = record.timestamp[:10] or "unknown"
+    return Path("runs") / f"dt={date}" / f"run-{record.run_id}.json"
+
+
+def write_record(record: RunRecord, store_dir: Path) -> Path:
+    """Write a record to its partition under store_dir.
+
+    Args:
+        record: The record to serialize
+        store_dir: Root of the store the partition path is resolved under
+
+    Returns:
+        The absolute path the record was written to
+    """
+    out_path = store_dir / partition_path(record)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(record.to_dict(), indent=2) + "\n", encoding="utf-8")
+    return out_path
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse the transform CLI arguments.
+
+    Args:
+        argv: Argument list, or None to read from sys.argv
+
+    Returns:
+        Parsed arguments with results_dir and store_dir
+    """
+    parser = argparse.ArgumentParser(description="Normalize a QA run's artifacts into a record.")
+    parser.add_argument(
+        "--results-dir",
+        type=Path,
+        default=Path(os.getenv("TEST_RESULTS_DIR", DEFAULT_RESULTS_DIR)),
+        help="Directory holding junit.xml, durations.json, navigation.json",
+    )
+    parser.add_argument(
+        "--store-dir",
+        type=Path,
+        default=Path(DEFAULT_RESULTS_DIR),
+        help="Root the partitioned record is written under",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Build a record from test-results/ and write it to the store.
+
+    Prints the written path to stdout so the workflow's load step can
+    stage exactly that file.
+
+    Args:
+        argv: Argument list, or None to read from sys.argv
+    """
+    args = _parse_args(argv)
+    results_dir: Path = args.results_dir
+    try:
+        junit_root: ET.Element | None = ET.parse(results_dir / JUNIT_NAME).getroot()
+    except (OSError, ET.ParseError):
+        junit_root = None
+    record = build_run_record(
+        durations=load_json(results_dir / DURATIONS_NAME),
+        navigation=load_json(results_dir / NAVIGATION_NAME),
+        junit_root=junit_root,
+        env=os.environ,
+    )
+    out_path = write_record(record, args.store_dir)
+    print(out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/transform.py
+++ b/pipeline/transform.py
@@ -149,18 +149,23 @@ def navigation_stats(navigation: dict[str, Any] | None) -> NavigationStats:
 
 
 def _run_identity(
-    durations: dict[str, Any] | None, navigation: dict[str, Any] | None
+    durations: dict[str, Any] | None,
+    navigation: dict[str, Any] | None,
+    env: Mapping[str, str],
 ) -> tuple[str, int | None, str]:
-    """Resolve run_id, run_number, and timestamp from whichever artifact has them.
+    """Resolve run_id, run_number, and timestamp from whichever source has them.
 
     Both metrics files carry the same identity block (conftest writes it
     from one helper), so either answers; durations is preferred and
     navigation is the fallback for a run that wrote only one. A run that
-    wrote neither is stamped now with a local id so it still records.
+    wrote neither - it died before pytest emitted any artifact - still
+    needs the real CI run id so its record keys and dedupes correctly, so
+    the environment is the last resort before the "local" default.
 
     Args:
         durations: Parsed durations.json, or None
         navigation: Parsed navigation.json, or None
+        env: Environment mapping, read for GITHUB_RUN_ID/GITHUB_RUN_NUMBER
 
     Returns:
         The run id, run number (or None), and ISO-8601 UTC timestamp
@@ -168,7 +173,12 @@ def _run_identity(
     for src in (durations, navigation):
         if src and src.get("run_id") and src.get("timestamp"):
             return src["run_id"], src.get("run_number"), src["timestamp"]
-    return "local", None, datetime.now(UTC).isoformat(timespec="seconds")
+    run_number = env.get("GITHUB_RUN_NUMBER")
+    return (
+        env.get("GITHUB_RUN_ID", "local"),
+        int(run_number) if run_number else None,
+        datetime.now(UTC).isoformat(timespec="seconds"),
+    )
 
 
 def build_run_record(
@@ -197,7 +207,7 @@ def build_run_record(
         counts, cases, wall_s = parse_junit(junit_root)
     else:
         counts, cases, wall_s = TestCounts(0, 0, 0, 0, 0, None), [], None
-    run_id, run_number, timestamp = _run_identity(durations, navigation)
+    run_id, run_number, timestamp = _run_identity(durations, navigation, env)
     return RunRecord(
         schema_version=SCHEMA_VERSION,
         run_id=run_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,13 @@ SMOKE_RERUN_DELAY_SECONDS = 5
 # that triggered the retry survives into durations.json.
 _test_durations: dict[str, list[tuple[float, str]]] = {}
 
+# The session's first-navigation measurement and the engine that took
+# it, stashed by the fixture so the sessionfinish hook can persist them.
+# Module-level like _test_durations because pytest hooks receive the
+# session, not fixtures, so there is no other handle onto the value.
+_first_navigation: FirstNavigation | None = None
+_first_navigation_browser: str | None = None
+
 # Load environment variables
 load_dotenv()
 
@@ -110,7 +117,10 @@ def first_navigation(browser: Browser, base_url: str) -> FirstNavigation:
     finally:
         context.close()
     logger.info("First navigation timing: %s (error: %s)", timing, error)
-    return FirstNavigation(timing=timing, error=error)
+    global _first_navigation, _first_navigation_browser
+    _first_navigation = FirstNavigation(timing=timing, error=error)
+    _first_navigation_browser = browser.browser_type.name
+    return _first_navigation
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
@@ -150,6 +160,52 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
         _test_durations.setdefault(report.nodeid, []).append((report.duration, report.outcome))
 
 
+def _run_metadata() -> dict[str, Any]:
+    """Build the run-identity block shared by every metrics artifact.
+
+    durations.json and navigation.json both key on the same run so the
+    transform stage (#33) can join them: run_id is that join key, taken
+    from GITHUB_RUN_ID (the store dedupes on it), and "local" off CI.
+
+    Returns:
+        Mapping with run_id, run_number, and an ISO-8601 UTC timestamp
+    """
+    run_number = os.getenv("GITHUB_RUN_NUMBER")
+    return {
+        "run_id": os.getenv("GITHUB_RUN_ID", "local"),
+        "run_number": int(run_number) if run_number else None,
+        "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+
+
+def _write_navigation_file() -> None:
+    """Persist the session's first-navigation timing as navigation.json.
+
+    The first_navigation fixture measures the site's own latency (TTFB,
+    domContentLoaded, load, connect) from the Navigation Timing API, but
+    until now only logged it, so the one performance signal the suite
+    takes expired with the run. Writing it makes each run's site latency
+    a durable metric the trend dashboard (#33) can chart. A failed
+    navigation is recorded as its error with null timing rather than
+    dropped, so an outage is a data point too. Stdlib only.
+    """
+    timing = _first_navigation.timing if _first_navigation is not None else None
+    error = _first_navigation.error if _first_navigation is not None else None
+    payload = {
+        **_run_metadata(),
+        "browser": _first_navigation_browser,
+        "navigation": {
+            "error": error,
+            "timing": timing._asdict() if timing is not None else None,
+        },
+    }
+    results_dir = Path(os.getenv("TEST_RESULTS_DIR", str(TEST_RESULTS_DIR)))
+    results_dir.mkdir(parents=True, exist_ok=True)
+    navigation_path = results_dir / "navigation.json"
+    navigation_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    logger.info("Navigation metrics saved: %s", navigation_path)
+
+
 def _write_durations_file() -> None:
     """Aggregate collected durations and write test-results/durations.json.
 
@@ -180,11 +236,8 @@ def _write_durations_file() -> None:
         p95 = statistics.quantiles(durations, n=20, method="inclusive")[-1]
     else:
         p95 = durations[0]
-    run_number = os.getenv("GITHUB_RUN_NUMBER")
     payload = {
-        "run_id": os.getenv("GITHUB_RUN_ID", "local"),
-        "run_number": int(run_number) if run_number else None,
-        "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
+        **_run_metadata(),
         "durations": {nodeid: round(d, 3) for nodeid, d in sorted(worst.items())},
         "retried": retried,
         "retried_count": len(retried),
@@ -206,11 +259,14 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> Generator[
 
     The hookwrapper=True makes this run around other sessionfinish hooks,
     and we recreate the directory right before yielding control. Duration
-    metrics are written here too, once all test reports are in.
+    and first-navigation metrics are written here too, once all test
+    reports and the session-scoped measurement are in.
     """
     TEST_RESULTS_DIR.mkdir(parents=True, exist_ok=True)
     if _test_durations:
         _write_durations_file()
+    if _first_navigation is not None:
+        _write_navigation_file()
     yield
     # Directory created, now pytest-html can write
 

--- a/tests/pipeline/test_aggregate.py
+++ b/tests/pipeline/test_aggregate.py
@@ -118,6 +118,8 @@ def test_load_records_reads_partitions_and_skips_corrupt(tmp_path: Path) -> None
     good_dir.mkdir(parents=True)
     (good_dir / "run-1.json").write_text(json.dumps(_record("1", "2026-07-20T06:00:00+00:00")))
     (good_dir / "run-bad.json").write_text("{broken", encoding="utf-8")
+    # A half-written record can be invalid UTF-8, not just invalid JSON.
+    (good_dir / "run-truncated.json").write_bytes(b'{"run_id": "\xff"}')
     records = load_records(tmp_path)
     assert len(records) == 1
     assert records[0]["run_id"] == "1"

--- a/tests/pipeline/test_aggregate.py
+++ b/tests/pipeline/test_aggregate.py
@@ -1,0 +1,123 @@
+"""Tests for the history-aggregation stage.
+
+These pin the fold from a directory of run records to the single
+time-ordered series the dashboard reads: field flattening, dedupe on
+run_id, ordering, and the incident summary.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pipeline.aggregate import (
+    build_history,
+    dedupe_by_run,
+    last_incident,
+    load_records,
+    to_series_entry,
+)
+
+
+def _record(run_id: str, timestamp: str, **over: Any) -> dict[str, Any]:
+    """Build a minimal run record dict, overridable per field group."""
+    record: dict[str, Any] = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "run_number": None,
+        "timestamp": timestamp,
+        "trigger": "schedule",
+        "browser": "chromium",
+        "commit_sha": None,
+        "counts": {"total": 7, "passed": 7, "failed": 0, "errors": 0, "pass_rate": 1.0},
+        "duration": {
+            "p95_s": 0.4,
+            "max_s": 0.5,
+            "wall_s": 3.0,
+            "slow_count": 0,
+            "retried_count": 0,
+        },
+        "navigation": {"error": None, "ttfb_ms": 50, "dom_content_loaded_ms": 120, "load_ms": 300},
+        "cases": [{"nodeid": "t::a", "outcome": "passed", "duration_s": 1.1}],
+    }
+    record.update(over)
+    return record
+
+
+def test_to_series_entry_flattens_and_drops_cases() -> None:
+    entry = to_series_entry(_record("1", "2026-07-20T06:00:00+00:00"))
+    assert entry["pass_rate"] == 1.0
+    assert entry["dom_content_loaded_ms"] == 120
+    assert entry["wall_s"] == 3.0
+    assert "cases" not in entry
+
+
+def test_dedupe_keeps_latest_timestamp_and_sorts_ascending() -> None:
+    older = to_series_entry(_record("1", "2026-07-20T06:00:00+00:00", trigger="old"))
+    newer = to_series_entry(_record("1", "2026-07-20T18:00:00+00:00", trigger="new"))
+    other = to_series_entry(_record("2", "2026-07-21T06:00:00+00:00"))
+    deduped = dedupe_by_run([newer, other, older])
+    assert [e["run_id"] for e in deduped] == ["1", "2"]
+    # The rerun (newer timestamp) wins for the collapsed run_id.
+    assert deduped[0]["trigger"] == "new"
+
+
+def test_last_incident_picks_most_recent_failure() -> None:
+    healthy = to_series_entry(_record("1", "2026-07-20T06:00:00+00:00"))
+    failed = to_series_entry(
+        _record(
+            "2",
+            "2026-07-20T18:00:00+00:00",
+            counts={"total": 7, "passed": 6, "failed": 1, "errors": 0, "pass_rate": 0.8571},
+        )
+    )
+    later_healthy = to_series_entry(_record("3", "2026-07-21T06:00:00+00:00"))
+    incident = last_incident([healthy, failed, later_healthy])
+    assert incident is not None
+    assert incident["run_id"] == "2"
+
+
+def test_navigation_failure_is_an_incident() -> None:
+    nav_down = to_series_entry(
+        _record(
+            "1",
+            "2026-07-20T06:00:00+00:00",
+            navigation={"error": "Timeout 20000ms", "ttfb_ms": None, "dom_content_loaded_ms": None},
+        )
+    )
+    assert last_incident([nav_down]) is not None
+
+
+def test_skip_only_run_is_not_an_incident() -> None:
+    # No failures and no nav error: a run that asserted nothing is not down.
+    skips = to_series_entry(
+        _record(
+            "1",
+            "2026-07-20T06:00:00+00:00",
+            counts={"total": 1, "passed": 0, "failed": 0, "errors": 0, "pass_rate": None},
+        )
+    )
+    assert last_incident([skips]) is None
+
+
+def test_all_healthy_has_no_incident() -> None:
+    entries = [to_series_entry(_record(str(i), f"2026-07-2{i}T06:00:00+00:00")) for i in range(3)]
+    assert last_incident(entries) is None
+
+
+def test_build_history_shape() -> None:
+    history = build_history([_record("1", "2026-07-20T06:00:00+00:00")])
+    assert history["run_count"] == 1
+    assert history["schema_version"] == 1
+    assert "generated_at" in history
+    assert history["runs"][0]["run_id"] == "1"
+    assert history["last_incident"] is None
+
+
+def test_load_records_reads_partitions_and_skips_corrupt(tmp_path: Path) -> None:
+    good_dir = tmp_path / "runs" / "dt=2026-07-20"
+    good_dir.mkdir(parents=True)
+    (good_dir / "run-1.json").write_text(json.dumps(_record("1", "2026-07-20T06:00:00+00:00")))
+    (good_dir / "run-bad.json").write_text("{broken", encoding="utf-8")
+    records = load_records(tmp_path)
+    assert len(records) == 1
+    assert records[0]["run_id"] == "1"

--- a/tests/pipeline/test_transform.py
+++ b/tests/pipeline/test_transform.py
@@ -191,6 +191,10 @@ def test_load_json_tolerates_missing_and_corrupt(tmp_path: Path) -> None:
     corrupt = tmp_path / "bad.json"
     corrupt.write_text("{not json", encoding="utf-8")
     assert load_json(corrupt) is None
+    # A half-written file can be invalid UTF-8, which read_text raises on.
+    non_utf8 = tmp_path / "truncated.json"
+    non_utf8.write_bytes(b'{"a": "\xff\xfe"}')
+    assert load_json(non_utf8) is None
     valid = tmp_path / "ok.json"
     valid.write_text('{"a": 1}', encoding="utf-8")
     assert load_json(valid) == {"a": 1}

--- a/tests/pipeline/test_transform.py
+++ b/tests/pipeline/test_transform.py
@@ -162,6 +162,15 @@ def test_run_identity_prefers_durations_then_navigation() -> None:
     assert neither.run_number is None
 
 
+def test_run_identity_falls_back_to_ci_env_when_no_artifacts() -> None:
+    # A run that died before any artifact was written still keys on the
+    # real CI run id, so its record dedupes instead of colliding on "local".
+    env = {"GITHUB_RUN_ID": "99999", "GITHUB_RUN_NUMBER": "7"}
+    record = build_run_record(None, None, None, env)
+    assert record.run_id == "99999"
+    assert record.run_number == 7
+
+
 def test_partition_path_is_date_partitioned_and_run_keyed() -> None:
     record = build_run_record(DURATIONS, NAVIGATION, None, {})
     assert partition_path(record) == Path("runs/dt=2026-07-20/run-12345.json")

--- a/tests/pipeline/test_transform.py
+++ b/tests/pipeline/test_transform.py
@@ -1,0 +1,187 @@
+"""Tests for the run-record transform stage.
+
+These pin the normalization offline: no browser, no network, no CI. Each
+raw artifact is fed in as the exact dict or XML a real run would write,
+so a schema drift in conftest or a mis-mapped field fails here rather
+than silently producing a wrong record in production.
+"""
+
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from pipeline.schema import SCHEMA_VERSION
+from pipeline.transform import (
+    build_run_record,
+    duration_stats,
+    load_json,
+    navigation_stats,
+    parse_junit,
+    partition_path,
+    write_record,
+)
+
+# A junit report with one of every outcome, mirroring pytest's xunit2
+# output: a bare <testcase> passed, and failure/error/skipped children.
+JUNIT_MIXED = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" tests="4" failures="1" errors="1" skipped="1" time="12.5">
+    <testcase classname="tests.smoke.test_smoke" name="test_homepage_loads" time="1.20"/>
+    <testcase classname="tests.smoke.test_smoke" name="test_warm" time="0.50">
+      <failure message="boom">assert 1 == 2</failure>
+    </testcase>
+    <testcase classname="tests.ui.test_ui_nav" name="test_nav" time="0.10">
+      <error message="fixture crash">Traceback</error>
+    </testcase>
+    <testcase classname="tests.smoke.test_smoke" name="test_redirect" time="0.00">
+      <skipped message="not https"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+DURATIONS = {
+    "run_id": "12345",
+    "run_number": 42,
+    "timestamp": "2026-07-20T22:51:42+00:00",
+    "durations": {"tests/smoke/test_smoke.py::test_homepage_loads": 1.2},
+    "retried": {},
+    "retried_count": 0,
+    "max_duration": 1.2,
+    "median_duration": 0.5,
+    "p95_duration": 1.14,
+    "slow_count": 0,
+}
+
+NAVIGATION = {
+    "run_id": "12345",
+    "run_number": 42,
+    "timestamp": "2026-07-20T22:51:42+00:00",
+    "browser": "chromium",
+    "navigation": {
+        "error": None,
+        "timing": {
+            "ttfb_ms": 50,
+            "dom_content_loaded_ms": 148.3,
+            "load_ms": 357.2,
+            "connect_ms": 36,
+        },
+    },
+}
+
+
+def test_parse_junit_counts_and_outcomes() -> None:
+    counts, cases, wall_s = parse_junit(ET.fromstring(JUNIT_MIXED))
+    assert (counts.total, counts.passed, counts.failed, counts.errors, counts.skipped) == (
+        4,
+        1,
+        1,
+        1,
+        1,
+    )
+    assert wall_s == 12.5
+    outcomes = {c.nodeid.split("::")[-1]: c.outcome for c in cases}
+    assert outcomes == {
+        "test_homepage_loads": "passed",
+        "test_warm": "failed",
+        "test_nav": "error",
+        "test_redirect": "skipped",
+    }
+
+
+def test_pass_rate_excludes_skips_from_denominator() -> None:
+    # 1 passed of (1 passed + 1 failed + 1 error) = 3 ran, skip excluded
+    counts, _, _ = parse_junit(ET.fromstring(JUNIT_MIXED))
+    assert counts.pass_rate == round(1 / 3, 4)
+
+
+def test_pass_rate_is_none_when_only_skips() -> None:
+    only_skips = """<testsuite tests="1" time="0.0">
+      <testcase classname="t" name="a" time="0.0"><skipped/></testcase>
+    </testsuite>"""
+    counts, _, _ = parse_junit(ET.fromstring(only_skips))
+    assert counts.pass_rate is None
+
+
+def test_duration_stats_maps_and_tolerates_absence() -> None:
+    stats = duration_stats(DURATIONS, wall_s=12.5)
+    assert (stats.max_s, stats.median_s, stats.p95_s, stats.wall_s) == (1.2, 0.5, 1.14, 12.5)
+    assert stats.slow_count == 0
+    empty = duration_stats(None, wall_s=None)
+    assert (empty.max_s, empty.p95_s, empty.retried_count, empty.wall_s) == (None, None, None, None)
+
+
+def test_navigation_stats_maps_timing() -> None:
+    stats = navigation_stats(NAVIGATION)
+    assert stats.error is None
+    assert (stats.ttfb_ms, stats.dom_content_loaded_ms, stats.load_ms, stats.connect_ms) == (
+        50,
+        148.3,
+        357.2,
+        36,
+    )
+
+
+def test_navigation_stats_failed_navigation_has_error_and_null_timing() -> None:
+    failed = {"navigation": {"error": "Timeout 20000ms exceeded", "timing": None}}
+    stats = navigation_stats(failed)
+    assert stats.error == "Timeout 20000ms exceeded"
+    assert stats.ttfb_ms is None and stats.load_ms is None
+
+
+def test_build_run_record_full() -> None:
+    env = {"GITHUB_EVENT_NAME": "schedule", "GITHUB_SHA": "abc123"}
+    record = build_run_record(DURATIONS, NAVIGATION, ET.fromstring(JUNIT_MIXED), env)
+    assert record.schema_version == SCHEMA_VERSION
+    assert record.run_id == "12345"
+    assert record.run_number == 42
+    assert record.trigger == "schedule"
+    assert record.commit_sha == "abc123"
+    assert record.browser == "chromium"
+    assert record.counts.total == 4
+    assert record.duration.wall_s == 12.5
+    assert record.navigation.ttfb_ms == 50
+    assert len(record.cases) == 4
+
+
+def test_build_run_record_survives_missing_junit() -> None:
+    # A run that died before pytest wrote junit still yields a record.
+    record = build_run_record(DURATIONS, NAVIGATION, None, {})
+    assert record.counts.total == 0
+    assert record.counts.pass_rate is None
+    assert record.cases == []
+    assert record.trigger == "local"
+    assert record.commit_sha is None
+
+
+def test_run_identity_prefers_durations_then_navigation() -> None:
+    nav_only = build_run_record(None, NAVIGATION, None, {})
+    assert nav_only.run_id == "12345"
+    neither = build_run_record(None, None, None, {})
+    assert neither.run_id == "local"
+    assert neither.run_number is None
+
+
+def test_partition_path_is_date_partitioned_and_run_keyed() -> None:
+    record = build_run_record(DURATIONS, NAVIGATION, None, {})
+    assert partition_path(record) == Path("runs/dt=2026-07-20/run-12345.json")
+
+
+def test_write_record_round_trips(tmp_path: Path) -> None:
+    record = build_run_record(DURATIONS, NAVIGATION, ET.fromstring(JUNIT_MIXED), {})
+    out_path = write_record(record, tmp_path)
+    assert out_path == tmp_path / "runs/dt=2026-07-20/run-12345.json"
+    reloaded = json.loads(out_path.read_text(encoding="utf-8"))
+    assert reloaded["run_id"] == "12345"
+    assert reloaded["counts"]["total"] == 4
+    assert reloaded["cases"][0]["outcome"] == "passed"
+
+
+def test_load_json_tolerates_missing_and_corrupt(tmp_path: Path) -> None:
+    assert load_json(tmp_path / "nope.json") is None
+    corrupt = tmp_path / "bad.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    assert load_json(corrupt) is None
+    valid = tmp_path / "ok.json"
+    valid.write_text('{"a": 1}', encoding="utf-8")
+    assert load_json(valid) == {"a": 1}


### PR DESCRIPTION
Closes #33.

Turns each scheduled QA run into durable trend data and serves it as a GitHub Pages dashboard, building out a small end-to-end pipeline: **extract → transform → load → serve**.

## What's here (one commit per stage)

1. **Extract** - persist the first-navigation timing (TTFB / DOM ready / load / connect) to `navigation.json`. It was already measured via the Navigation Timing API but only logged, so the one performance signal each run took expired with the run.
2. **Transform** - a stdlib-only `pipeline/` package: `schema.py` (frozen-dataclass `RunRecord` with a `SCHEMA_VERSION`) + `transform.py` joins `junit.xml` + `durations.json` + `navigation.json` into one record keyed by run ID, written to `runs/dt=YYYY-MM-DD/run-<id>.json`.
3. **Aggregate** - `pipeline/aggregate.py` folds the record store into one `history.json` (deduped on run ID, time-sorted, with a last-incident summary).
4. **Serve** - `dashboard/index.html`: self-contained, no-dependency SVG charts (pass-rate trend, page-load latency trend, incident summary, full run table) with a crosshair/tooltip hover layer, validated light + dark.
5. **Load + publish** - a `publish` job in `tests.yml` commits the record to an orphan **`metrics-data`** branch (git as a zero-infra store), aggregates, and deploys the dashboard to Pages.
6. **Docs** - README pipeline diagram, run-record schema table, and setup notes.

## Acceptance criteria

- **N runs → N records**: each run appends one partitioned JSON to the store.
- **Dashboard renders from stored history**, not the latest run only.
- **Idempotent**: records are keyed by run ID (re-run overwrites in place) and the commit step no-ops when unchanged - verified against a local bare repo (orphan init → append → idempotent re-run → aggregate).

## One-time setup required

GitHub Pages must be set to **Source: GitHub Actions** (Settings → Pages). Until then the pipeline still runs and records still accrue on `metrics-data`; only the Pages deploy step is skipped. The store branch bootstraps itself on the first scheduled run.

## Verification

- `ruff check` / `ruff format --check` / `mypy` (strict) clean across the repo.
- 21 pipeline unit tests + offline suite green (39 passed).
- Transform + aggregate exercised against real live-site artifacts and a synthetic multi-run store; dashboard render verified in-browser across light/dark (no horizontal overflow, correct incident marking, table view).

The static dashboard could not be raster-screenshotted (sandboxed browser), so it was verified via DOM/geometry inspection rather than an attached image.