### PR TITLE
fix: count dashboard tests against non-skipped total (#74)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -383,7 +383,9 @@ function tile(label, value, note) {
 // consistently with it - a fully-green run is 64/64, not 64/65.
 function ranAndSkipped(r) {
   const ran = (r.passed || 0) + (r.failed || 0) + (r.errors || 0);
-  const skipped = typeof r.total === "number" ? Math.max(0, r.total - ran) : 0;
+  // null (not 0) when total is unknown, so a display can tell "zero
+  // skips" apart from "no data" - the em dash is reserved for the latter.
+  const skipped = typeof r.total === "number" ? Math.max(0, r.total - ran) : null;
   return { ran, skipped };
 }
 
@@ -438,7 +440,7 @@ function tableView(runs) {
       <td class="${down ? "fail" : "ok"}">${down ? "down" : "up"}</td>
       <td>${r.pass_rate != null ? Math.round(r.pass_rate * 1000) / 10 + "%" : "—"}</td>
       <td>${r.passed != null ? `${r.passed}/${ran}` : "—"}</td>
-      <td>${skipped || "—"}</td>
+      <td>${skipped ?? "—"}</td>
       <td>${num(r.ttfb_ms)}</td>
       <td>${num(r.dom_content_loaded_ms)}</td>
       <td>${num(r.load_ms)}</td>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -378,16 +378,29 @@ function tile(label, value, note) {
   return `<div class="tile"><div class="label">${label}</div><div class="value">${value}</div><div class="note">${note || ""}</div></div>`;
 }
 
+// Tests that made an assertion (skips excluded) and the skip count.
+// pass_rate is passed/ran, so counts shown against `ran` read
+// consistently with it - a fully-green run is 64/64, not 64/65.
+function ranAndSkipped(r) {
+  const ran = (r.passed || 0) + (r.failed || 0) + (r.errors || 0);
+  const skipped = typeof r.total === "number" ? Math.max(0, r.total - ran) : 0;
+  return { ran, skipped };
+}
+
 function renderTiles(history) {
   const runs = history.runs || [];
   const last = runs[runs.length - 1] || {};
   const passRate = last.pass_rate != null ? Math.round(last.pass_rate * 1000) / 10 + "%" : "—";
   const dcl = typeof last.dom_content_loaded_ms === "number" ? Math.round(last.dom_content_loaded_ms) + "<small> ms</small>" : "—";
+  const { ran, skipped } = ranAndSkipped(last);
+  const passNote = last.passed != null
+    ? `${last.passed}/${ran} passing${skipped ? ` · ${skipped} skipped` : ""}`
+    : "";
   const inc = history.last_incident;
   const incNote = inc ? relTime(inc.timestamp) : "none on record";
   const incVal = inc ? fmtDate(inc.timestamp, false) : "None";
   return `<section class="tiles">
-    ${tile("Latest pass rate", passRate, last.passed != null ? `${last.passed}/${last.total} tests` : "")}
+    ${tile("Latest pass rate", passRate, passNote)}
     ${tile("Latest DOM ready", dcl, "first navigation")}
     ${tile("Runs tracked", history.run_count ?? runs.length, "scheduled QA runs")}
     ${tile("Last incident", incVal, incNote)}
@@ -419,11 +432,13 @@ function renderIncident(history) {
 function tableView(runs) {
   const rows = runs.slice().reverse().map(r => {
     const down = r.failed > 0 || r.errors > 0 || r.nav_error;
+    const { ran, skipped } = ranAndSkipped(r);
     return `<tr>
       <td>${fmtDate(r.timestamp, true)}</td>
       <td class="${down ? "fail" : "ok"}">${down ? "down" : "up"}</td>
       <td>${r.pass_rate != null ? Math.round(r.pass_rate * 1000) / 10 + "%" : "—"}</td>
-      <td>${r.passed ?? "—"}/${r.total ?? "—"}</td>
+      <td>${r.passed != null ? `${r.passed}/${ran}` : "—"}</td>
+      <td>${skipped || "—"}</td>
       <td>${num(r.ttfb_ms)}</td>
       <td>${num(r.dom_content_loaded_ms)}</td>
       <td>${num(r.load_ms)}</td>
@@ -431,7 +446,7 @@ function tableView(runs) {
   }).join("");
   return `<details class="table-view"><summary>View all runs as a table</summary>
     <div class="table-scroll"><table>
-      <thead><tr><th>Run</th><th>Status</th><th>Pass</th><th>Tests</th><th>TTFB ms</th><th>DOM ms</th><th>Load ms</th></tr></thead>
+      <thead><tr><th>Run</th><th>Status</th><th>Pass</th><th>Passing</th><th>Skip</th><th>TTFB ms</th><th>DOM ms</th><th>Load ms</th></tr></thead>
       <tbody>${rows}</tbody>
     </table></div></details>`;
 }


### PR DESCRIPTION
Closes #74.

## Problem

The dashboard's pass-rate tile read **100%** but noted **64/65 tests**, and the run table showed **64/65** - the `/65` counted a *skipped* test, so a fully-healthy run looked like one test wasn't passing. Inconsistent with `pass_rate`, which already excludes skips (`passed / passed+failed+errors`).

## Fix

Display counts against `ran = passed + failed + errors` (matching the pass-rate denominator) and surface skips explicitly:

- Pass-rate tile note: **`64/64 passing · 1 skipped`** (was `64/65 tests`)
- Run table: split **`Passing`** (`64/64`) and **`Skip`** (`1`) columns

A run with a real failure still reads correctly (`63/64 passing`, status `down`). Dashboard-only change - no schema or pipeline change, since `history.json` already carries `passed`/`failed`/`errors`/`total`.

## Verification

In-browser against sample history with (a) a skipped-only healthy run → tile `100%` / `64/64 passing · 1 skipped`, and (b) a run with a failure → `98.4%` / `63/64 passing` / `down`.