### PR TITLE
docs: add separate CI and QA badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # site-sentry
 
+[![CI](https://github.com/dardenkyle/site-sentry/actions/workflows/ci.yml/badge.svg)](https://github.com/dardenkyle/site-sentry/actions/workflows/ci.yml)
 [![QA Tests](https://github.com/dardenkyle/site-sentry/actions/workflows/tests.yml/badge.svg)](https://github.com/dardenkyle/site-sentry/actions/workflows/tests.yml)
 [![Last Commit](https://img.shields.io/github/last-commit/dardenkyle/site-sentry?label=last%20commit&color=brightgreen)](https://github.com/dardenkyle/site-sentry/commits/main)
 


### PR DESCRIPTION
## Summary
Adds a CI badge (ci.yml) ahead of the existing QA Tests badge (tests.yml) so the README distinguishes push/PR code validation from scheduled production site-health monitoring at a glance. The Last Commit badge already covered the maintenance-recency criterion.

Closes #21